### PR TITLE
[💄Design/#5] 캘린더 화면 리디자인

### DIFF
--- a/src/app/calendar/calendar.module.css
+++ b/src/app/calendar/calendar.module.css
@@ -2,8 +2,15 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  min-height: 100vh;
+  background: var(--color-surface);
 }
 
 .main {
-  padding: 32px;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  background: var(--color-surface);
 }

--- a/src/app/calendar/layout.tsx
+++ b/src/app/calendar/layout.tsx
@@ -1,4 +1,4 @@
-import CalendarNav from '@/components/layout/CalendarNav'
+import CalendarTopbar from '@/components/calendar/CalendarTopbar'
 import styles from './calendar.module.css'
 
 export default function CalendarLayout({
@@ -8,7 +8,7 @@ export default function CalendarLayout({
 }) {
   return (
     <div className={styles.content}>
-      <CalendarNav />
+      <CalendarTopbar />
       <main className={styles.main}>{children}</main>
     </div>
   )

--- a/src/app/calendar/monthly/page.tsx
+++ b/src/app/calendar/monthly/page.tsx
@@ -1,7 +1,5 @@
+import MonthlyCalendarView from '@/components/calendar/MonthlyCalendarView'
+
 export default function MonthlyPage() {
-  return (
-    <main>
-      <h1>먼슬리</h1>
-    </main>
-  )
+  return <MonthlyCalendarView />
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,32 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f7f8f6;
+  --foreground: #1e241f;
+  --color-bg: #f7f8f6;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f1f4f0;
+  --color-border: #dde4da;
+  --color-border-soft: #edf1eb;
+  --color-text: #1e241f;
+  --color-text-muted: #677067;
+  --color-text-subtle: #8a938a;
+  --color-brand: #3f8f5f;
+  --color-brand-strong: #2f744c;
+  --color-brand-soft: #e7f4ec;
+  --color-hover: #f3f6f2;
+  --color-active: #e7f4ec;
+  --color-work: #3b82f6;
+  --color-routine: #22c55e;
+  --color-personal: #f59e0b;
+  --color-study: #8b5cf6;
+  --color-important: #ef4444;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --shadow-sm: 0 1px 2px rgba(20, 28, 20, 0.06);
+  --shadow-md: 0 8px 24px rgba(20, 28, 20, 0.08);
+  --shadow-popover: 0 16px 40px rgba(20, 28, 20, 0.14);
 }
 
 @theme inline {
@@ -12,15 +36,26 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
 }

--- a/src/components/calendar/CalendarTopbar.tsx
+++ b/src/components/calendar/CalendarTopbar.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import styles from './calendarTopbar.module.css'
+
+const views = [
+  { label: '일', href: '/calendar' },
+  { label: '주', href: '/calendar/weekly' },
+  { label: '월', href: '/calendar/monthly' },
+]
+
+export default function CalendarTopbar() {
+  const pathname = usePathname()
+
+  return (
+    <header className={styles.topbar}>
+      <div className={styles.leftGroup}>
+        <button className={styles.todayButton} type="button">
+          오늘
+        </button>
+        <div className={styles.monthControls} aria-label="월 이동">
+          <button className={styles.iconButton} type="button" aria-label="이전 달">
+            &lt;
+          </button>
+          <button className={styles.iconButton} type="button" aria-label="다음 달">
+            &gt;
+          </button>
+        </div>
+        <h1 className={styles.currentMonth}>2026년 6월</h1>
+      </div>
+
+      <div className={styles.rightGroup}>
+        <label className={styles.search}>
+          <span className={styles.searchIcon}>Search</span>
+          <input type="search" placeholder="일정 검색" aria-label="일정 검색" />
+        </label>
+        <nav className={styles.viewSwitcher} aria-label="캘린더 보기">
+          {views.map((view) => (
+            <Link
+              key={view.href}
+              href={view.href}
+              className={`${styles.viewLink} ${pathname === view.href ? styles.activeView : ''}`}
+            >
+              {view.label}
+            </Link>
+          ))}
+        </nav>
+        <button className={styles.iconButton} type="button" aria-label="설정">
+          설정
+        </button>
+        <button className={styles.avatarButton} type="button" aria-label="프로필">
+          DL
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/calendar/MonthlyCalendarView.tsx
+++ b/src/components/calendar/MonthlyCalendarView.tsx
@@ -1,0 +1,64 @@
+import { getCategoryById, getMonthDays, sampleEvents } from '@/lib/calendar'
+import styles from './monthlyCalendarView.module.css'
+
+const weekdays = ['일', '월', '화', '수', '목', '금', '토']
+
+export default function MonthlyCalendarView() {
+  const days = getMonthDays()
+
+  return (
+    <section className={styles.monthlyView} aria-label="월간 캘린더">
+      <div className={styles.weekHeader}>
+        {weekdays.map((weekday) => (
+          <div key={weekday} className={styles.weekday}>
+            {weekday}
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.monthGrid}>
+        {days.map((day) => {
+          const events = sampleEvents.filter((event) => event.date === day.key)
+          const visibleEvents = events.slice(0, 3)
+          const hiddenCount = events.length - visibleEvents.length
+
+          return (
+            <article
+              key={day.key}
+              className={`${styles.dayCell} ${day.isCurrentMonth ? '' : styles.outsideMonth}`}
+            >
+              <div className={styles.dayHeader}>
+                <span className={day.isToday ? styles.today : styles.dayNumber}>
+                  {day.dayNumber}
+                </span>
+              </div>
+
+              <div className={styles.eventList}>
+                {visibleEvents.map((event) => {
+                  const category = getCategoryById(event.categoryId)
+
+                  return (
+                    <div
+                      key={event.id}
+                      className={styles.eventChip}
+                      style={{ '--event-color': category?.color } as React.CSSProperties}
+                    >
+                      <span className={styles.eventDot} />
+                      <span className={styles.eventTime}>{event.time}</span>
+                      <span className={styles.eventTitle}>{event.title}</span>
+                    </div>
+                  )
+                })}
+                {hiddenCount > 0 ? (
+                  <button className={styles.moreButton} type="button">
+                    +{hiddenCount}개 더보기
+                  </button>
+                ) : null}
+              </div>
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/calendar/calendarTopbar.module.css
+++ b/src/components/calendar/calendarTopbar.module.css
@@ -1,0 +1,165 @@
+.topbar {
+  height: 68px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 24px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border-soft);
+}
+
+.leftGroup,
+.rightGroup,
+.monthControls {
+  display: flex;
+  align-items: center;
+}
+
+.leftGroup {
+  gap: 14px;
+  min-width: 0;
+}
+
+.rightGroup {
+  gap: 10px;
+  min-width: 0;
+}
+
+.todayButton,
+.iconButton,
+.avatarButton,
+.viewLink {
+  height: 36px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-radius: var(--radius-md);
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.todayButton {
+  padding: 0 15px;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.iconButton {
+  min-width: 36px;
+  padding: 0 10px;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.todayButton:hover,
+.iconButton:hover,
+.avatarButton:hover,
+.viewLink:hover {
+  background: var(--color-hover);
+  border-color: var(--color-brand);
+}
+
+.monthControls {
+  gap: 6px;
+}
+
+.currentMonth {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 22px;
+  font-weight: 750;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.search {
+  width: min(260px, 24vw);
+  height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+}
+
+.searchIcon {
+  font-size: 11px;
+  font-weight: 650;
+  color: var(--color-text-subtle);
+}
+
+.search input {
+  width: 100%;
+  min-width: 64px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 14px;
+}
+
+.search input::placeholder {
+  color: var(--color-text-subtle);
+}
+
+.viewSwitcher {
+  display: grid;
+  grid-template-columns: repeat(3, 38px);
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted);
+}
+
+.viewLink {
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.activeView {
+  background: var(--color-surface);
+  color: var(--color-brand-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.avatarButton {
+  width: 36px;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--color-brand-soft);
+  color: var(--color-brand-strong);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+@media (max-width: 1040px) {
+  .search {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .topbar {
+    height: auto;
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 14px 16px;
+  }
+
+  .rightGroup {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/src/components/calendar/monthlyCalendarView.module.css
+++ b/src/components/calendar/monthlyCalendarView.module.css
@@ -1,0 +1,149 @@
+.monthlyView {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: 42px minmax(0, 1fr);
+  overflow: hidden;
+  background: var(--color-surface);
+}
+
+.weekHeader {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  border-bottom: 1px solid var(--color-border-soft);
+  background: var(--color-surface);
+}
+
+.weekday {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 12px;
+  border-right: 1px solid var(--color-border-soft);
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.weekday:last-child {
+  border-right: 0;
+}
+
+.monthGrid {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  grid-template-rows: repeat(6, minmax(92px, 1fr));
+}
+
+.dayCell {
+  min-width: 0;
+  min-height: 92px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border-right: 1px solid var(--color-border-soft);
+  border-bottom: 1px solid var(--color-border-soft);
+  background: var(--color-surface);
+}
+
+.dayCell:nth-child(7n) {
+  border-right: 0;
+}
+
+.outsideMonth {
+  background: #fafbf9;
+  color: var(--color-text-subtle);
+}
+
+.dayHeader {
+  min-height: 28px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dayNumber,
+.today {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.dayNumber {
+  color: var(--color-text-muted);
+}
+
+.today {
+  background: var(--color-brand);
+  color: #ffffff;
+}
+
+.eventList {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.eventChip {
+  height: 24px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 7px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--event-color, var(--color-brand)) 12%, white);
+  color: var(--color-text);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.eventDot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--event-color, var(--color-brand));
+}
+
+.eventTime {
+  flex: 0 0 auto;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.eventTitle {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.moreButton {
+  height: 22px;
+  width: fit-content;
+  max-width: 100%;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-brand-strong);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.moreButton:hover {
+  background: var(--color-brand-soft);
+}
+
+@media (max-width: 820px) {
+  .monthlyView {
+    min-width: 760px;
+  }
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,25 +1,110 @@
+'use client'
+
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { calendarCategories } from '@/lib/calendar'
 import styles from './sidebar.module.css'
 
+const navItems = [
+  { label: '캘린더', href: '/calendar/monthly' },
+  { label: '라이브러리', href: '/library' },
+  { label: '루틴', href: '/routine' },
+  { label: '일기', href: '/' },
+  { label: '친구', href: '/' },
+  { label: '설정', href: '/' },
+]
+
+const miniDays = Array.from({ length: 35 }, (_, index) => index - 1)
+
 export default function Sidebar() {
+  const pathname = usePathname()
+
   return (
     <aside className={styles.sidebar}>
       <div className={styles.logo}>
-        <span>🍀</span>
+        <span className={styles.logoMark}>D</span>
         <span>DayLeaf</span>
       </div>
-      <div className={styles.profile}>
-        <span>프로필</span>
-        <span>닉네임</span>
-      </div>
+
+      <button className={styles.createButton} type="button">
+        + 새 일정
+      </button>
+
       <nav className={styles.nav}>
-        <Link href="/calendar">캘린더</Link>
-        <Link href="/library">라이브러리</Link>
-        <Link href="/routine">루틴</Link>
-        <Link href="/">일기</Link>
-        <Link href="/">친구</Link>
-        <Link href="/">설정</Link>
+        {navItems.map((item) => {
+          const isActive =
+            item.href === '/'
+              ? pathname === item.href
+              : pathname.startsWith(item.href.replace('/monthly', ''))
+
+          return (
+            <Link
+              key={item.label}
+              href={item.href}
+              className={`${styles.navLink} ${isActive ? styles.activeNavLink : ''}`}
+            >
+              {item.label}
+            </Link>
+          )
+        })}
       </nav>
+
+      <section className={styles.section} aria-labelledby="mini-calendar-title">
+        <div className={styles.sectionHeader}>
+          <h2 id="mini-calendar-title">2026년 6월</h2>
+          <div className={styles.miniActions}>
+            <button type="button" aria-label="이전 달">
+              &lt;
+            </button>
+            <button type="button" aria-label="다음 달">
+              &gt;
+            </button>
+          </div>
+        </div>
+        <div className={styles.miniCalendar}>
+          {['일', '월', '화', '수', '목', '금', '토'].map((weekday) => (
+            <span key={weekday} className={styles.weekday}>
+              {weekday}
+            </span>
+          ))}
+          {miniDays.map((day, index) => (
+            <button
+              key={`${day}-${index}`}
+              className={`${styles.miniDay} ${day === 5 ? styles.selectedMiniDay : ''} ${
+                day < 1 || day > 30 ? styles.mutedMiniDay : ''
+              }`}
+              type="button"
+            >
+              {day < 1 ? '' : day > 30 ? '' : day}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section} aria-labelledby="category-title">
+        <h2 id="category-title">캘린더</h2>
+        <div className={styles.categoryList}>
+          {calendarCategories.map((category) => (
+            <label key={category.id} className={styles.categoryItem}>
+              <input type="checkbox" defaultChecked />
+              <span className={styles.categoryDot} style={{ background: category.color }} />
+              <span>{category.label}</span>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section} aria-labelledby="filter-title">
+        <h2 id="filter-title">필터</h2>
+        <div className={styles.filterList}>
+          {['전체 일정', '반복 일정', '완료된 일정'].map((filter, index) => (
+            <label key={filter} className={styles.filterItem}>
+              <input type="checkbox" defaultChecked={index < 2} />
+              <span>{filter}</span>
+            </label>
+          ))}
+        </div>
+      </section>
     </aside>
   )
 }

--- a/src/components/layout/sidebar.module.css
+++ b/src/components/layout/sidebar.module.css
@@ -1,35 +1,198 @@
 .sidebar {
-  width: 200px;
+  width: 280px;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  padding: 24px;
-  border-right: 1px solid #eee;
+  gap: 22px;
+  padding: 22px 18px;
+  border-right: 1px solid var(--color-border-soft);
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 
 .logo {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 24px;
-  font-weight: bold;
+  gap: 10px;
+  font-weight: 800;
   font-size: 18px;
 }
 
-.profile {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 24px;
+.logoMark {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-md);
+  background: var(--color-brand);
+  color: #ffffff;
+  font-size: 15px;
+  box-shadow: var(--shadow-sm);
+}
+
+.createButton {
+  height: 42px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--color-brand);
+  color: #ffffff;
   font-size: 14px;
+  font-weight: 750;
+  box-shadow: var(--shadow-sm);
+}
+
+.createButton:hover {
+  background: var(--color-brand-strong);
 }
 
 .nav {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 4px;
 }
 
-.nav a {
-  text-decoration: none;
-  color: inherit;
+.navLink {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.navLink:hover {
+  background: var(--color-hover);
+  color: var(--color-text);
+}
+
+.activeNavLink {
+  background: var(--color-active);
+  color: var(--color-brand-strong);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section h2 {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.miniActions {
+  display: flex;
+  gap: 4px;
+}
+
+.miniActions button {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.miniActions button:hover {
+  border-color: var(--color-brand);
+  background: var(--color-hover);
+}
+
+.miniCalendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.weekday {
+  height: 24px;
+  display: grid;
+  place-items: center;
+  color: var(--color-text-subtle);
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.miniDay {
+  aspect-ratio: 1;
+  min-width: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.miniDay:hover {
+  background: var(--color-hover);
+}
+
+.selectedMiniDay {
+  background: var(--color-brand);
+  color: #ffffff;
+}
+
+.mutedMiniDay {
+  color: transparent;
+  pointer-events: none;
+}
+
+.categoryList,
+.filterList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.categoryItem,
+.filterItem {
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.categoryItem input,
+.filterItem input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--color-brand);
+}
+
+.categoryDot {
+  width: 9px;
+  height: 9px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+}
+
+@media (max-width: 980px) {
+  .sidebar {
+    width: 236px;
+  }
+}
+
+@media (max-width: 760px) {
+  .sidebar {
+    display: none;
+  }
 }

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,65 @@
+import dayjs from 'dayjs'
+
+export type CalendarView = 'day' | 'week' | 'month'
+
+export type CalendarCategory = {
+  id: string
+  label: string
+  color: string
+}
+
+export type CalendarEvent = {
+  id: string
+  title: string
+  date: string
+  time?: string
+  categoryId: string
+}
+
+export type CalendarDay = {
+  key: string
+  date: dayjs.Dayjs
+  dayNumber: number
+  isCurrentMonth: boolean
+  isToday: boolean
+}
+
+export const calendarCategories: CalendarCategory[] = [
+  { id: 'work', label: '업무', color: 'var(--color-work)' },
+  { id: 'routine', label: '루틴', color: 'var(--color-routine)' },
+  { id: 'personal', label: '개인', color: 'var(--color-personal)' },
+  { id: 'study', label: '공부', color: 'var(--color-study)' },
+  { id: 'important', label: '중요', color: 'var(--color-important)' },
+]
+
+export const sampleEvents: CalendarEvent[] = [
+  { id: '1', title: '캡스톤 회의', date: '2026-06-05', time: '10:00', categoryId: 'work' },
+  { id: '2', title: 'UI 리디자인', date: '2026-06-08', time: '14:00', categoryId: 'study' },
+  { id: '3', title: '아침 루틴', date: '2026-06-10', time: '08:30', categoryId: 'routine' },
+  { id: '4', title: '친구 약속', date: '2026-06-13', time: '18:00', categoryId: 'personal' },
+  { id: '5', title: '중간 발표', date: '2026-06-18', time: '11:00', categoryId: 'important' },
+  { id: '6', title: '기획 정리', date: '2026-06-18', time: '16:00', categoryId: 'work' },
+  { id: '7', title: '회고 작성', date: '2026-06-24', time: '21:00', categoryId: 'routine' },
+]
+
+export function getMonthDays(baseDate = '2026-06-01') {
+  const month = dayjs(baseDate).startOf('month')
+  const start = month.startOf('week')
+  const today = dayjs()
+
+  return Array.from({ length: 42 }, (_, index): CalendarDay => {
+    const date = start.add(index, 'day')
+
+    return {
+      key: date.format('YYYY-MM-DD'),
+      date,
+      dayNumber: date.date(),
+      isCurrentMonth: date.month() === month.month(),
+      isToday: date.isSame(today, 'day'),
+    }
+  })
+}
+
+export function getCategoryById(categoryId: string) {
+  return calendarCategories.find((category) => category.id === categoryId)
+}


### PR DESCRIPTION
## 📣 Related Issue
- #5

## 📝 Summary
- AI 도구(Codex)를 활용해 캘린더 화면 리디자인 초안을 구현했습니다.
- 프로젝트 공통 디자인 토큰을 `globals.css`에 추가했습니다.
- Sidebar를 새 디자인 시스템에 맞게 리디자인했습니다.
  - 새 일정 버튼
  - 미니 캘린더
  - 캘린더 카테고리
  - 일정 필터
  - active navigation 상태
- Calendar Topbar를 새로 구현했습니다.
  - 오늘 버튼
  - 월 이동 버튼
  - 현재 월 표시
  - 일정 검색
  - 일/주/月 view switcher
  - 설정/프로필 영역
- Monthly Calendar View를 구현했습니다.
  - 월간 날짜 그리드
  - 요일 헤더
  - 오늘 날짜 상태
  - 이전/다음 달 날짜 상태
  - 일정 chip UI
  - 카테고리별 색상 표시
- 날짜/카테고리/샘플 일정 데이터를 `src/lib/calendar.ts`로 분리했습니다.
- 추후 Weekly/Daily View 확장을 고려해 캘린더 UI를 `components/calendar` 하위 컴포넌트로 분리했습니다.

## 🙏PR point
- 아이콘 패키지는 추가하지 않고 텍스트 기반 버튼으로 먼저 구현했습니다. 추후 `lucide-react` 등을 도입하면 Topbar/Sidebar 버튼을 더 자연스럽게 개선할 수 있을 것으로 예상합니다.

## 📬 Reference
- Google Calendar의 정보 구조와 월간 캘린더 UI 패턴을 참고했습니다.
- 구현 코드는 AI 도구(Codex)를 활용해 생성했습니다.