### PR TITLE
[✨Feat/#4] 주간 캘린더 뷰 구현

### DIFF
--- a/src/app/calendar/layout.tsx
+++ b/src/app/calendar/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import CalendarTopbar from '@/components/calendar/CalendarTopbar'
 import styles from './calendar.module.css'
 
@@ -8,7 +9,9 @@ export default function CalendarLayout({
 }) {
   return (
     <div className={styles.content}>
-      <CalendarTopbar />
+      <Suspense fallback={null}>
+        <CalendarTopbar />
+      </Suspense>
       <main className={styles.main}>{children}</main>
     </div>
   )

--- a/src/app/calendar/weekly/page.tsx
+++ b/src/app/calendar/weekly/page.tsx
@@ -1,7 +1,10 @@
+import { Suspense } from 'react'
+import WeeklyCalendar from '@/components/calendar/weekly/WeeklyCalendar'
+
 export default function WeeklyPage() {
   return (
-    <main>
-      <h1>위클리</h1>
-    </main>
+    <Suspense fallback={null}>
+      <WeeklyCalendar />
+    </Suspense>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,8 @@
   --space-10: 40px;
   --calendar-modal-width: 440px;
   --calendar-min-width: 760px;
+  --calendar-time-column-width: 72px;
+  --calendar-hour-height: 64px;
   --radius-sm: 6px;
   --radius-md: 8px;
   --radius-lg: 12px;

--- a/src/components/calendar/CalendarTopbar.tsx
+++ b/src/components/calendar/CalendarTopbar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import styles from './calendarTopbar.module.css'
 
 const views = [
@@ -12,6 +12,10 @@ const views = [
 
 export default function CalendarTopbar() {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const isWeeklyView = pathname === '/calendar/weekly'
+  const isTodoOpen = searchParams.get('todo') === 'open'
+  const todoHref = isTodoOpen ? '/calendar/weekly' : '/calendar/weekly?todo=open'
 
   return (
     <header className={styles.topbar}>
@@ -46,6 +50,14 @@ export default function CalendarTopbar() {
             </Link>
           ))}
         </nav>
+        {isWeeklyView ? (
+          <Link
+            href={todoHref}
+            className={`${styles.todoButton} ${isTodoOpen ? styles.activeTodoButton : ''}`}
+          >
+            Todo
+          </Link>
+        ) : null}
         <button className={styles.iconButton} type="button" aria-label="설정">
           설정
         </button>

--- a/src/components/calendar/calendarTopbar.module.css
+++ b/src/components/calendar/calendarTopbar.module.css
@@ -29,7 +29,8 @@
 .todayButton,
 .iconButton,
 .avatarButton,
-.viewLink {
+.viewLink,
+.todoButton {
   height: 36px;
   border: 1px solid var(--color-border);
   background: var(--color-surface);
@@ -128,10 +129,25 @@
   font-weight: 650;
 }
 
+.todoButton {
+  display: grid;
+  place-items: center;
+  padding: 0 var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 750;
+}
+
 .activeView {
   background: var(--color-surface);
   color: var(--color-brand-strong);
   box-shadow: var(--shadow-sm);
+}
+
+.activeTodoButton {
+  border-color: var(--color-brand);
+  background: var(--color-brand-soft);
+  color: var(--color-brand-strong);
 }
 
 .avatarButton {

--- a/src/components/calendar/weekly/CalendarEvent.tsx
+++ b/src/components/calendar/weekly/CalendarEvent.tsx
@@ -1,0 +1,176 @@
+import { useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from 'react'
+import {
+  clampMinute,
+  getEventDuration,
+  getMinuteFromPointer,
+  timeToMinutes,
+} from '@/lib/calendar'
+import type { CalendarEvent as CalendarEventType } from '@/types/calendar'
+import styles from './weeklyCalendar.module.css'
+
+type CalendarEventProps = {
+  event: CalendarEventType
+  offset: number
+  duration: number
+  onClick: (event: CalendarEventType) => void
+  onMove: (
+    event: CalendarEventType,
+    nextDate: string,
+    startMinute: number,
+    endMinute: number,
+  ) => void
+  onResize: (event: CalendarEventType, startMinute: number, endMinute: number) => void
+}
+
+function getTargetColumn(clientX: number, clientY: number) {
+  const target = document.elementFromPoint(clientX, clientY)
+  return target?.closest<HTMLElement>('[data-week-day-column="true"]')
+}
+
+const resizeThreshold = 8
+const dragThreshold = 5
+const interactionSnapStep = 15
+
+function getResizeEdge(pointerEvent: PointerEvent<HTMLDivElement>) {
+  const rect = pointerEvent.currentTarget.getBoundingClientRect()
+
+  if (pointerEvent.clientY - rect.top <= resizeThreshold) {
+    return 'top'
+  }
+
+  if (rect.bottom - pointerEvent.clientY <= resizeThreshold) {
+    return 'bottom'
+  }
+
+  return null
+}
+
+export default function CalendarEvent({
+  event,
+  offset,
+  duration,
+  onClick,
+  onMove,
+  onResize,
+}: CalendarEventProps) {
+  const [cursorMode, setCursorMode] = useState<'move' | 'resize'>('move')
+
+  const handlePointerDown = (pointerEvent: PointerEvent<HTMLDivElement>) => {
+    if (pointerEvent.button !== 0) {
+      return
+    }
+
+    pointerEvent.stopPropagation()
+    pointerEvent.currentTarget.setPointerCapture(pointerEvent.pointerId)
+
+    const resizeEdge = getResizeEdge(pointerEvent)
+    const startMinute = timeToMinutes(event.startTime)
+    const endMinute = timeToMinutes(event.endTime)
+    const eventDuration = getEventDuration(event.startTime, event.endTime)
+    const column = pointerEvent.currentTarget.closest<HTMLElement>('[data-week-day-column="true"]')
+    const pointerMinute = column
+      ? getMinuteFromPointer(pointerEvent.clientY, column.getBoundingClientRect(), interactionSnapStep)
+      : startMinute
+    const pointerOffsetMinute = pointerMinute - startMinute
+    const startClientX = pointerEvent.clientX
+    const startClientY = pointerEvent.clientY
+    let didMove = false
+
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      const movementX = Math.abs(moveEvent.clientX - startClientX)
+      const movementY = Math.abs(moveEvent.clientY - startClientY)
+
+      if (movementX < dragThreshold && movementY < dragThreshold) {
+        return
+      }
+
+      didMove = true
+
+      if (resizeEdge && column) {
+        const pointerMinuteOnColumn = getMinuteFromPointer(
+          moveEvent.clientY,
+          column.getBoundingClientRect(),
+          interactionSnapStep,
+        )
+
+        if (resizeEdge === 'top') {
+          onResize(event, Math.min(pointerMinuteOnColumn, endMinute - 30), endMinute)
+          return
+        }
+
+        onResize(event, startMinute, Math.max(pointerMinuteOnColumn, startMinute + 30))
+        return
+      }
+
+      const nextColumn = getTargetColumn(moveEvent.clientX, moveEvent.clientY)
+
+      if (!nextColumn) {
+        return
+      }
+
+      const rawStartMinute =
+        getMinuteFromPointer(
+          moveEvent.clientY,
+          nextColumn.getBoundingClientRect(),
+          interactionSnapStep,
+        ) -
+        pointerOffsetMinute
+      const nextStartMinute = clampMinute(
+        Math.min(rawStartMinute, 24 * 60 - eventDuration),
+      )
+      const nextDate = nextColumn.dataset.date
+
+      if (!nextDate) {
+        return
+      }
+
+      onMove(event, nextDate, nextStartMinute, nextStartMinute + eventDuration)
+    }
+
+    const handlePointerUp = () => {
+      document.removeEventListener('pointermove', handlePointerMove)
+      document.removeEventListener('pointerup', handlePointerUp)
+
+      if (!didMove) {
+        onClick(event)
+      }
+    }
+
+    document.addEventListener('pointermove', handlePointerMove)
+    document.addEventListener('pointerup', handlePointerUp, { once: true })
+  }
+
+  const handleKeyDown = (keyEvent: KeyboardEvent<HTMLDivElement>) => {
+    if (keyEvent.key === 'Enter' || keyEvent.key === ' ') {
+      keyEvent.preventDefault()
+      onClick(event)
+    }
+  }
+
+  return (
+    <div
+      className={styles.eventBlock}
+      data-cursor-mode={cursorMode}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      onPointerMove={(pointerEvent) => {
+        setCursorMode(getResizeEdge(pointerEvent) ? 'resize' : 'move')
+      }}
+      onPointerLeave={() => setCursorMode('move')}
+      style={
+        {
+          '--event-color': event.color,
+          '--event-offset': `${(offset / 1440) * 100}%`,
+          '--event-height': `${(duration / 1440) * 100}%`,
+        } as CSSProperties
+      }
+    >
+      <span className={styles.eventTitle}>{event.title}</span>
+      <span className={styles.eventTime}>
+        {event.startTime} - {event.endTime}
+      </span>
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/CalendarEvent.tsx
+++ b/src/components/calendar/weekly/CalendarEvent.tsx
@@ -3,6 +3,7 @@ import {
   clampMinute,
   getEventDuration,
   getMinuteFromPointer,
+  minutesToTime,
   timeToMinutes,
 } from '@/lib/calendar'
 import type { CalendarEvent as CalendarEventType } from '@/types/calendar'
@@ -19,6 +20,7 @@ type CalendarEventProps = {
     startMinute: number,
     endMinute: number,
   ) => void
+  onResizeEnd: () => void
   onResize: (event: CalendarEventType, startMinute: number, endMinute: number) => void
 }
 
@@ -51,9 +53,18 @@ export default function CalendarEvent({
   duration,
   onClick,
   onMove,
+  onResizeEnd,
   onResize,
 }: CalendarEventProps) {
   const [cursorMode, setCursorMode] = useState<'move' | 'resize'>('move')
+  const [resizeFeedback, setResizeFeedback] = useState<{
+    edge: 'top' | 'bottom'
+    time: string
+  } | null>(null)
+  const displayStartTime =
+    resizeFeedback?.edge === 'top' ? resizeFeedback.time : event.startTime
+  const displayEndTime =
+    resizeFeedback?.edge === 'bottom' ? resizeFeedback.time : event.endTime
 
   const handlePointerDown = (pointerEvent: PointerEvent<HTMLDivElement>) => {
     if (pointerEvent.button !== 0) {
@@ -94,11 +105,15 @@ export default function CalendarEvent({
         )
 
         if (resizeEdge === 'top') {
-          onResize(event, Math.min(pointerMinuteOnColumn, endMinute - 30), endMinute)
+          const nextStartMinute = Math.min(pointerMinuteOnColumn, endMinute - 30)
+          setResizeFeedback({ edge: 'top', time: minutesToTime(nextStartMinute) })
+          onResize(event, nextStartMinute, endMinute)
           return
         }
 
-        onResize(event, startMinute, Math.max(pointerMinuteOnColumn, startMinute + 30))
+        const nextEndMinute = Math.max(pointerMinuteOnColumn, startMinute + 30)
+        setResizeFeedback({ edge: 'bottom', time: minutesToTime(nextEndMinute) })
+        onResize(event, startMinute, nextEndMinute)
         return
       }
 
@@ -130,6 +145,12 @@ export default function CalendarEvent({
     const handlePointerUp = () => {
       document.removeEventListener('pointermove', handlePointerMove)
       document.removeEventListener('pointerup', handlePointerUp)
+
+      if (resizeEdge && didMove) {
+        onResizeEnd()
+      }
+
+      setResizeFeedback(null)
 
       if (!didMove) {
         onClick(event)
@@ -169,7 +190,21 @@ export default function CalendarEvent({
     >
       <span className={styles.eventTitle}>{event.title}</span>
       <span className={styles.eventTime}>
-        {event.startTime} - {event.endTime}
+        <span
+          className={
+            resizeFeedback?.edge === 'top' ? styles.activeResizeTime : undefined
+          }
+        >
+          {displayStartTime}
+        </span>
+        <span className={styles.eventTimeDivider}>-</span>
+        <span
+          className={
+            resizeFeedback?.edge === 'bottom' ? styles.activeResizeTime : undefined
+          }
+        >
+          {displayEndTime}
+        </span>
       </span>
     </div>
   )

--- a/src/components/calendar/weekly/DayColumn.tsx
+++ b/src/components/calendar/weekly/DayColumn.tsx
@@ -1,0 +1,186 @@
+import { useRef, useState, type CSSProperties, type PointerEvent } from 'react'
+import {
+  getEventDuration,
+  getEventOffset,
+  getMinuteFromPointer,
+  minutesToTime,
+} from '@/lib/calendar'
+import type { CalendarDay, CalendarEvent as CalendarEventType } from '@/types/calendar'
+import CalendarEvent from './CalendarEvent'
+import styles from './weeklyCalendar.module.css'
+
+type DayColumnProps = {
+  day: CalendarDay
+  events: CalendarEventType[]
+  selection: { startMinute: number; endMinute: number } | null
+  timeSlots: string[]
+  onCreateEvent: (day: CalendarDay, startMinute: number, endMinute: number) => void
+  onEditEvent: (event: CalendarEventType) => void
+  onMoveEvent: (
+    event: CalendarEventType,
+    nextDate: string,
+    startMinute: number,
+    endMinute: number,
+  ) => void
+  onResizeEvent: (event: CalendarEventType, startMinute: number, endMinute: number) => void
+}
+
+type SelectionState = {
+  anchorMinute: number
+  clickMinute: number
+  startClientX: number
+  startClientY: number
+  startMinute: number
+  endMinute: number
+}
+
+const clickThreshold = 5
+const clickSnapStep = 30
+const dragSnapStep = 15
+
+export default function DayColumn({
+  day,
+  events,
+  selection,
+  timeSlots,
+  onCreateEvent,
+  onEditEvent,
+  onMoveEvent,
+  onResizeEvent,
+}: DayColumnProps) {
+  const columnRef = useRef<HTMLDivElement>(null)
+  const [draftSelection, setDraftSelection] = useState<SelectionState | null>(null)
+
+  const getColumnRect = () => columnRef.current?.getBoundingClientRect()
+
+  const handlePointerDown = (pointerEvent: PointerEvent<HTMLElement>) => {
+    if (pointerEvent.button !== 0) {
+      return
+    }
+
+    pointerEvent.stopPropagation()
+    pointerEvent.currentTarget.setPointerCapture(pointerEvent.pointerId)
+    const rect = getColumnRect()
+
+    if (!rect) {
+      return
+    }
+
+    const dragMinute = Math.min(
+      getMinuteFromPointer(pointerEvent.clientY, rect, dragSnapStep),
+      24 * 60 - 15,
+    )
+    const clickMinute = Math.min(
+      getMinuteFromPointer(pointerEvent.clientY, rect, clickSnapStep),
+      24 * 60 - 60,
+    )
+
+    setDraftSelection({
+      anchorMinute: dragMinute,
+      clickMinute,
+      startClientX: pointerEvent.clientX,
+      startClientY: pointerEvent.clientY,
+      startMinute: dragMinute,
+      endMinute: Math.min(dragMinute + 15, 24 * 60),
+    })
+  }
+
+  const handlePointerMove = (pointerEvent: PointerEvent<HTMLElement>) => {
+    if (!draftSelection) {
+      return
+    }
+
+    const rect = getColumnRect()
+
+    if (!rect) {
+      return
+    }
+
+    const nextMinute = getMinuteFromPointer(pointerEvent.clientY, rect, dragSnapStep)
+    const startMinute = Math.min(draftSelection.anchorMinute, nextMinute)
+    const endMinute = Math.max(draftSelection.anchorMinute, nextMinute)
+
+    setDraftSelection({
+      ...draftSelection,
+      startMinute,
+      endMinute: endMinute === startMinute ? startMinute + 15 : endMinute,
+    })
+  }
+
+  const handlePointerUp = (pointerEvent: PointerEvent<HTMLElement>) => {
+    if (!draftSelection) {
+      return
+    }
+
+    if (pointerEvent.currentTarget.hasPointerCapture(pointerEvent.pointerId)) {
+      pointerEvent.currentTarget.releasePointerCapture(pointerEvent.pointerId)
+    }
+
+    const movementX = Math.abs(pointerEvent.clientX - draftSelection.startClientX)
+    const movementY = Math.abs(pointerEvent.clientY - draftSelection.startClientY)
+    const isClick = movementX < clickThreshold && movementY < clickThreshold
+    const startMinute = isClick ? draftSelection.clickMinute : draftSelection.startMinute
+    const minimumDuration = isClick ? 60 : 15
+    const endMinute = isClick
+      ? Math.min(startMinute + 60, 24 * 60)
+      : Math.min(Math.max(draftSelection.endMinute, startMinute + minimumDuration), 24 * 60)
+
+    setDraftSelection(null)
+    onCreateEvent(day, startMinute, endMinute)
+  }
+
+  const visibleSelection = draftSelection ?? selection
+
+  return (
+    <div
+      ref={columnRef}
+      className={styles.dayColumn}
+      data-week-day-column="true"
+      data-date={day.key}
+      aria-label={`${day.key} 일정 추가`}
+    >
+      <div className={styles.hourLines}>
+        {timeSlots.map((time) => (
+          <span key={time} className={styles.hourLine} />
+        ))}
+      </div>
+      <div className={styles.hourHoverGrid}>
+        {timeSlots.map((time) => (
+          <button
+            key={time}
+            className={styles.hourHoverSlot}
+            type="button"
+            aria-label={`${day.key} ${time} 일정 추가`}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+          />
+        ))}
+      </div>
+      {visibleSelection ? (
+        <span
+          className={styles.selectionBlock}
+          style={
+            {
+              '--selection-offset': `${(visibleSelection.startMinute / 1440) * 100}%`,
+              '--selection-height': `${((visibleSelection.endMinute - visibleSelection.startMinute) / 1440) * 100}%`,
+            } as CSSProperties
+          }
+        >
+          {minutesToTime(visibleSelection.startMinute)} - {minutesToTime(visibleSelection.endMinute)}
+        </span>
+      ) : null}
+      {events.map((event) => (
+        <CalendarEvent
+          key={event.id}
+          event={event}
+          duration={getEventDuration(event.startTime, event.endTime)}
+          offset={getEventOffset(event.startTime)}
+          onClick={onEditEvent}
+          onMove={onMoveEvent}
+          onResize={onResizeEvent}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/DayColumn.tsx
+++ b/src/components/calendar/weekly/DayColumn.tsx
@@ -22,12 +22,14 @@ type DayColumnProps = {
     startMinute: number,
     endMinute: number,
   ) => void
+  onResizeEnd: () => void
   onResizeEvent: (event: CalendarEventType, startMinute: number, endMinute: number) => void
 }
 
 type SelectionState = {
   anchorMinute: number
   clickMinute: number
+  isDragging: boolean
   startClientX: number
   startClientY: number
   startMinute: number
@@ -35,7 +37,6 @@ type SelectionState = {
 }
 
 const clickThreshold = 5
-const clickSnapStep = 30
 const dragSnapStep = 15
 
 export default function DayColumn({
@@ -46,6 +47,7 @@ export default function DayColumn({
   onCreateEvent,
   onEditEvent,
   onMoveEvent,
+  onResizeEnd,
   onResizeEvent,
 }: DayColumnProps) {
   const columnRef = useRef<HTMLDivElement>(null)
@@ -53,7 +55,7 @@ export default function DayColumn({
 
   const getColumnRect = () => columnRef.current?.getBoundingClientRect()
 
-  const handlePointerDown = (pointerEvent: PointerEvent<HTMLElement>) => {
+  const handlePointerDown = (pointerEvent: PointerEvent<HTMLElement>, startHour: number) => {
     if (pointerEvent.button !== 0) {
       return
     }
@@ -70,14 +72,12 @@ export default function DayColumn({
       getMinuteFromPointer(pointerEvent.clientY, rect, dragSnapStep),
       24 * 60 - 15,
     )
-    const clickMinute = Math.min(
-      getMinuteFromPointer(pointerEvent.clientY, rect, clickSnapStep),
-      24 * 60 - 60,
-    )
+    const clickMinute = Math.min(startHour * 60, 24 * 60 - 60)
 
     setDraftSelection({
       anchorMinute: dragMinute,
       clickMinute,
+      isDragging: false,
       startClientX: pointerEvent.clientX,
       startClientY: pointerEvent.clientY,
       startMinute: dragMinute,
@@ -87,6 +87,17 @@ export default function DayColumn({
 
   const handlePointerMove = (pointerEvent: PointerEvent<HTMLElement>) => {
     if (!draftSelection) {
+      return
+    }
+
+    const movementX = Math.abs(pointerEvent.clientX - draftSelection.startClientX)
+    const movementY = Math.abs(pointerEvent.clientY - draftSelection.startClientY)
+
+    if (
+      !draftSelection.isDragging &&
+      movementX <= clickThreshold &&
+      movementY <= clickThreshold
+    ) {
       return
     }
 
@@ -102,6 +113,7 @@ export default function DayColumn({
 
     setDraftSelection({
       ...draftSelection,
+      isDragging: true,
       startMinute,
       endMinute: endMinute === startMinute ? startMinute + 15 : endMinute,
     })
@@ -118,7 +130,8 @@ export default function DayColumn({
 
     const movementX = Math.abs(pointerEvent.clientX - draftSelection.startClientX)
     const movementY = Math.abs(pointerEvent.clientY - draftSelection.startClientY)
-    const isClick = movementX < clickThreshold && movementY < clickThreshold
+    const isClick =
+      !draftSelection.isDragging && movementX <= clickThreshold && movementY <= clickThreshold
     const startMinute = isClick ? draftSelection.clickMinute : draftSelection.startMinute
     const minimumDuration = isClick ? 60 : 15
     const endMinute = isClick
@@ -129,7 +142,7 @@ export default function DayColumn({
     onCreateEvent(day, startMinute, endMinute)
   }
 
-  const visibleSelection = draftSelection ?? selection
+  const visibleSelection = draftSelection?.isDragging ? draftSelection : selection
 
   return (
     <div
@@ -145,13 +158,13 @@ export default function DayColumn({
         ))}
       </div>
       <div className={styles.hourHoverGrid}>
-        {timeSlots.map((time) => (
+        {timeSlots.map((time, index) => (
           <button
             key={time}
             className={styles.hourHoverSlot}
             type="button"
             aria-label={`${day.key} ${time} 일정 추가`}
-            onPointerDown={handlePointerDown}
+            onPointerDown={(pointerEvent) => handlePointerDown(pointerEvent, index)}
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}
           />
@@ -178,6 +191,7 @@ export default function DayColumn({
           offset={getEventOffset(event.startTime)}
           onClick={onEditEvent}
           onMove={onMoveEvent}
+          onResizeEnd={onResizeEnd}
           onResize={onResizeEvent}
         />
       ))}

--- a/src/components/calendar/weekly/EventModal.tsx
+++ b/src/components/calendar/weekly/EventModal.tsx
@@ -1,0 +1,194 @@
+import { useState, type FormEvent } from 'react'
+import type {
+  CalendarCategory,
+  CalendarEvent,
+  CalendarEventDraft,
+  RecurrenceFrequency,
+  RecurrenceRule,
+} from '@/types/calendar'
+import styles from './weeklyCalendar.module.css'
+
+type EventModalProps = {
+  categories: CalendarCategory[]
+  defaultDate: string
+  defaultStartTime: string
+  defaultEndTime: string
+  event?: CalendarEvent
+  getCategoryColor: (categoryId: string) => string
+  mode: 'create' | 'edit'
+  onClose: () => void
+  onDelete: () => void
+  onSave: (draft: CalendarEventDraft) => void
+}
+
+const defaultCategoryId = 'work'
+
+const recurrenceOptions: Array<{ label: string; value: RecurrenceFrequency }> = [
+  { label: '반복 안 함', value: 'NONE' },
+  { label: '매일', value: 'DAILY' },
+  { label: '매주', value: 'WEEKLY' },
+  { label: '평일마다', value: 'WEEKDAYS' },
+  { label: '매월', value: 'MONTHLY' },
+  { label: '사용자 정의', value: 'CUSTOM' },
+]
+
+function getRecurrenceRule(frequency: RecurrenceFrequency): RecurrenceRule | undefined {
+  if (frequency === 'NONE') {
+    return undefined
+  }
+
+  if (frequency === 'WEEKDAYS') {
+    return { frequency, interval: 1, byWeekDay: ['MO', 'TU', 'WE', 'TH', 'FR'] }
+  }
+
+  return { frequency, interval: 1 }
+}
+
+export default function EventModal({
+  categories,
+  defaultDate,
+  defaultEndTime,
+  defaultStartTime,
+  event,
+  getCategoryColor,
+  mode,
+  onClose,
+  onDelete,
+  onSave,
+}: EventModalProps) {
+  const [title, setTitle] = useState(event?.title ?? '')
+  const [description, setDescription] = useState(event?.description ?? '')
+  const [date, setDate] = useState(event?.date ?? defaultDate)
+  const [startTime, setStartTime] = useState(event?.startTime ?? defaultStartTime)
+  const [endTime, setEndTime] = useState(event?.endTime ?? defaultEndTime)
+  const [categoryId, setCategoryId] = useState(event?.categoryId ?? defaultCategoryId)
+  const [recurrenceFrequency, setRecurrenceFrequency] = useState<RecurrenceFrequency>(
+    event?.recurrenceRule?.frequency ?? 'NONE',
+  )
+
+  const handleSubmit = (submitEvent: FormEvent<HTMLFormElement>) => {
+    submitEvent.preventDefault()
+
+    onSave({
+      title: title.trim() || '제목 없는 일정',
+      description: description.trim(),
+      date,
+      startTime,
+      endTime,
+      categoryId,
+      color: getCategoryColor(categoryId),
+      recurrenceRule: getRecurrenceRule(recurrenceFrequency),
+    })
+  }
+
+  return (
+    <div className={styles.modalOverlay} role="presentation" onClick={onClose}>
+      <form
+        className={styles.eventModal}
+        onClick={(clickEvent) => clickEvent.stopPropagation()}
+        onSubmit={handleSubmit}
+      >
+        <div className={styles.modalHeader}>
+          <div>
+            <p className={styles.modalEyebrow}>{mode === 'edit' ? '일정 수정' : '일정 추가'}</p>
+            <h2>{mode === 'edit' ? '주간 일정을 수정합니다' : '주간 일정을 만듭니다'}</h2>
+          </div>
+          <button className={styles.closeButton} type="button" onClick={onClose} aria-label="닫기">
+            x
+          </button>
+        </div>
+
+        <label className={styles.field}>
+          <span>제목</span>
+          <input value={title} onChange={(changeEvent) => setTitle(changeEvent.target.value)} />
+        </label>
+
+        <label className={styles.field}>
+          <span>날짜</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(changeEvent) => setDate(changeEvent.target.value)}
+            required
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span>설명</span>
+          <textarea
+            value={description}
+            onChange={(changeEvent) => setDescription(changeEvent.target.value)}
+            rows={3}
+          />
+        </label>
+
+        <div className={styles.timeFields}>
+          <label className={styles.field}>
+            <span>시작</span>
+            <input
+              type="time"
+              value={startTime}
+              onChange={(changeEvent) => setStartTime(changeEvent.target.value)}
+              required
+            />
+          </label>
+          <label className={styles.field}>
+            <span>종료</span>
+            <input
+              type="time"
+              value={endTime}
+              onChange={(changeEvent) => setEndTime(changeEvent.target.value)}
+              required
+            />
+          </label>
+        </div>
+
+        <label className={styles.field}>
+          <span>카테고리</span>
+          <select
+            value={categoryId}
+            onChange={(changeEvent) => setCategoryId(changeEvent.target.value)}
+          >
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={styles.field}>
+          <span>반복</span>
+          <select
+            value={recurrenceFrequency}
+            onChange={(changeEvent) =>
+              setRecurrenceFrequency(changeEvent.target.value as RecurrenceFrequency)
+            }
+          >
+            {recurrenceOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className={styles.modalActions}>
+          {mode === 'edit' ? (
+            <button className={styles.deleteButton} type="button" onClick={onDelete}>
+              삭제
+            </button>
+          ) : null}
+          <div className={styles.actionGroup}>
+            <button className={styles.secondaryButton} type="button" onClick={onClose}>
+              취소
+            </button>
+            <button className={styles.primaryButton} type="submit">
+              저장
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/TimeColumn.tsx
+++ b/src/components/calendar/weekly/TimeColumn.tsx
@@ -1,0 +1,17 @@
+import styles from './weeklyCalendar.module.css'
+
+type TimeColumnProps = {
+  timeSlots: string[]
+}
+
+export default function TimeColumn({ timeSlots }: TimeColumnProps) {
+  return (
+    <div className={styles.timeColumn} aria-hidden="true">
+      {timeSlots.map((time) => (
+        <div key={time} className={styles.timeSlot}>
+          {time}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/TodoForm.tsx
+++ b/src/components/calendar/weekly/TodoForm.tsx
@@ -1,0 +1,55 @@
+import { useState, type KeyboardEvent } from 'react'
+import type { CalendarDay } from '@/types/calendar'
+import styles from './weeklyCalendar.module.css'
+
+type TodoFormProps = {
+  day: CalendarDay
+  onAddTodo: (title: string, createdAt: string) => void
+}
+
+export default function TodoForm({ day, onAddTodo }: TodoFormProps) {
+  const [title, setTitle] = useState('')
+
+  const saveTodo = () => {
+    const nextTitle = title.trim()
+
+    if (!nextTitle) {
+      return
+    }
+
+    onAddTodo(nextTitle, day.key)
+    setTitle('')
+  }
+
+  const handleKeyDown = (keyEvent: KeyboardEvent<HTMLInputElement>) => {
+    if (keyEvent.nativeEvent.isComposing) {
+      return
+    }
+
+    if (keyEvent.key === 'Enter') {
+      keyEvent.preventDefault()
+      saveTodo()
+    }
+  }
+
+  return (
+    <div className={styles.todoForm}>
+      <input type="checkbox" disabled aria-hidden="true" />
+      <input
+        value={title}
+        onChange={(changeEvent) => setTitle(changeEvent.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="new todo"
+        aria-label={`${day.key} Todo 추가`}
+      />
+      {title.trim() ? (
+        <button
+          className={styles.todoSubmitButton}
+          type="button"
+          onClick={saveTodo}
+          aria-label={`${day.key} Todo 등록`}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/TodoItem.tsx
+++ b/src/components/calendar/weekly/TodoItem.tsx
@@ -1,0 +1,64 @@
+import { useState, type FormEvent } from 'react'
+import type { CalendarTodo } from '@/types/calendar'
+import styles from './weeklyCalendar.module.css'
+
+type TodoItemProps = {
+  todo: CalendarTodo
+  onDeleteTodo: (todoId: string) => void
+  onToggleTodo: (todoId: string) => void
+  onUpdateTodo: (todoId: string, title: string) => void
+}
+
+export default function TodoItem({
+  todo,
+  onDeleteTodo,
+  onToggleTodo,
+  onUpdateTodo,
+}: TodoItemProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [title, setTitle] = useState(todo.title)
+
+  const handleSubmit = (submitEvent: FormEvent<HTMLFormElement>) => {
+    submitEvent.preventDefault()
+    const nextTitle = title.trim()
+
+    if (!nextTitle) {
+      return
+    }
+
+    onUpdateTodo(todo.id, nextTitle)
+    setIsEditing(false)
+  }
+
+  return (
+    <div className={styles.todoItem}>
+      <input
+        className={styles.todoCheckbox}
+        type="checkbox"
+        checked={todo.completed}
+        onChange={() => onToggleTodo(todo.id)}
+      />
+      {isEditing ? (
+        <form className={styles.todoEditForm} onSubmit={handleSubmit}>
+          <input value={title} onChange={(changeEvent) => setTitle(changeEvent.target.value)} />
+        </form>
+      ) : (
+        <button
+          className={`${styles.todoTitle} ${todo.completed ? styles.completedTodo : ''}`}
+          type="button"
+          onClick={() => setIsEditing(true)}
+        >
+          {todo.title}
+        </button>
+      )}
+      <button
+        className={styles.todoDeleteButton}
+        type="button"
+        aria-label={`${todo.title} 삭제`}
+        onClick={() => onDeleteTodo(todo.id)}
+      >
+        x
+      </button>
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/TodoPanel.tsx
+++ b/src/components/calendar/weekly/TodoPanel.tsx
@@ -1,0 +1,52 @@
+import type { CalendarDay, CalendarTodo } from '@/types/calendar'
+import TodoForm from './TodoForm'
+import TodoItem from './TodoItem'
+import styles from './weeklyCalendar.module.css'
+
+type TodoPanelProps = {
+  days: CalendarDay[]
+  todos: CalendarTodo[]
+  onAddTodo: (title: string, createdAt: string) => void
+  onDeleteTodo: (todoId: string) => void
+  onToggleTodo: (todoId: string) => void
+  onUpdateTodo: (todoId: string, title: string) => void
+}
+
+export default function TodoPanel({
+  days,
+  todos,
+  onAddTodo,
+  onDeleteTodo,
+  onToggleTodo,
+  onUpdateTodo,
+}: TodoPanelProps) {
+  return (
+    <section className={styles.todoPanel} aria-label="주간 할 일">
+      <div className={styles.todoPanelOffset} />
+      <div className={styles.todoPanelContent}>
+        <div className={styles.todoDayGrid}>
+          {days.map((day) => {
+            const dayTodos = todos.filter((todo) => todo.createdAt === day.key)
+
+            return (
+              <section key={day.key} className={styles.todoDayColumn} aria-label={`${day.key} 할 일`}>
+                <div className={styles.todoList}>
+                  {dayTodos.map((todo) => (
+                    <TodoItem
+                      key={todo.id}
+                      todo={todo}
+                      onDeleteTodo={onDeleteTodo}
+                      onToggleTodo={onToggleTodo}
+                      onUpdateTodo={onUpdateTodo}
+                    />
+                  ))}
+                  <TodoForm day={day} onAddTodo={onAddTodo} />
+                </div>
+              </section>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/calendar/weekly/WeekDayHeader.tsx
+++ b/src/components/calendar/weekly/WeekDayHeader.tsx
@@ -1,0 +1,26 @@
+import type { CalendarDay } from '@/types/calendar'
+import styles from './weeklyCalendar.module.css'
+
+const weekdays = ['월', '화', '수', '목', '금', '토', '일']
+
+type WeekDayHeaderProps = {
+  days: CalendarDay[]
+}
+
+export default function WeekDayHeader({ days }: WeekDayHeaderProps) {
+  return (
+    <div className={styles.weekHeader}>
+      <div className={styles.timeHeader} />
+      <div className={styles.dayHeaderGrid}>
+        {days.map((day, index) => (
+          <div key={day.key} className={styles.dayHeaderCell}>
+            <span className={styles.weekday}>{weekdays[index]}</span>
+            <span className={day.isToday ? styles.todayDate : styles.dateNumber}>
+              {day.dayNumber}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/WeeklyCalendar.tsx
+++ b/src/components/calendar/weekly/WeeklyCalendar.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import {
+  calendarCategories,
+  getCategoryColor,
+  getTimeSlots,
+  getWeekDays,
+  minutesToTime,
+  sampleEvents,
+  sampleTodos,
+} from '@/lib/calendar'
+import type { CalendarDay, CalendarEvent, CalendarEventDraft, CalendarTodo } from '@/types/calendar'
+import EventModal from './EventModal'
+import TodoPanel from './TodoPanel'
+import WeekDayHeader from './WeekDayHeader'
+import WeeklyGrid from './WeeklyGrid'
+import styles from './weeklyCalendar.module.css'
+
+const selectedWeek = '2026-06-05'
+
+type ModalState =
+  | { mode: 'create'; date: string; startTime: string; endTime: string; event?: undefined }
+  | { mode: 'edit'; event: CalendarEvent }
+  | null
+
+type SelectionState = {
+  date: string
+  startMinute: number
+  endMinute: number
+}
+
+export default function WeeklyCalendar() {
+  const searchParams = useSearchParams()
+  const isTodoOpen = searchParams.get('todo') === 'open'
+  const [events, setEvents] = useState<CalendarEvent[]>(sampleEvents)
+  const [todos, setTodos] = useState<CalendarTodo[]>(sampleTodos)
+  const [modalState, setModalState] = useState<ModalState>(null)
+  const [selection, setSelection] = useState<SelectionState | null>(null)
+
+  const days = useMemo(() => getWeekDays(selectedWeek), [])
+  const timeSlots = useMemo(() => getTimeSlots(), [])
+  const eventsByDate = useMemo(() => {
+    return events.reduce<Record<string, CalendarEvent[]>>((groupedEvents, event) => {
+      const dayEvents = groupedEvents[event.date] ?? []
+      return {
+        ...groupedEvents,
+        [event.date]: [...dayEvents, event].sort((first, second) =>
+          first.startTime.localeCompare(second.startTime),
+        ),
+      }
+    }, {})
+  }, [events])
+
+  const handleCreateEvent = (day: CalendarDay, startMinute: number, endMinute: number) => {
+    setSelection({ date: day.key, startMinute, endMinute })
+    setModalState({
+      mode: 'create',
+      date: day.key,
+      startTime: minutesToTime(startMinute),
+      endTime: minutesToTime(endMinute),
+    })
+  }
+
+  const handleEditEvent = (event: CalendarEvent) => {
+    setModalState({ mode: 'edit', event })
+  }
+
+  const handleSaveEvent = (draft: CalendarEventDraft) => {
+    if (modalState?.mode === 'edit') {
+      setEvents((currentEvents) =>
+        currentEvents.map((event) =>
+          event.id === modalState.event.id ? { ...draft, id: modalState.event.id } : event,
+        ),
+      )
+      setModalState(null)
+      setSelection(null)
+      return
+    }
+
+    setEvents((currentEvents) => [...currentEvents, { ...draft, id: `${Date.now()}` }])
+    setModalState(null)
+    setSelection(null)
+  }
+
+  const handleMoveEvent = (
+    targetEvent: CalendarEvent,
+    nextDate: string,
+    startMinute: number,
+    endMinute: number,
+  ) => {
+    setEvents((currentEvents) =>
+      currentEvents.map((event) =>
+        event.id === targetEvent.id
+          ? {
+              ...event,
+              date: nextDate,
+              startTime: minutesToTime(startMinute),
+              endTime: minutesToTime(endMinute),
+            }
+          : event,
+      ),
+    )
+  }
+
+  const handleResizeEvent = (
+    targetEvent: CalendarEvent,
+    startMinute: number,
+    endMinute: number,
+  ) => {
+    setEvents((currentEvents) =>
+      currentEvents.map((event) =>
+        event.id === targetEvent.id
+          ? {
+              ...event,
+              startTime: minutesToTime(startMinute),
+              endTime: minutesToTime(endMinute),
+            }
+          : event,
+      ),
+    )
+  }
+
+  const handleDeleteEvent = () => {
+    if (modalState?.mode !== 'edit') {
+      return
+    }
+
+    setEvents((currentEvents) =>
+      currentEvents.filter((event) => event.id !== modalState.event.id),
+    )
+    setModalState(null)
+  }
+
+  const handleCloseModal = () => {
+    setModalState(null)
+    setSelection(null)
+  }
+
+  const handleAddTodo = (title: string, createdAt: string) => {
+    setTodos((currentTodos) => [
+      ...currentTodos,
+      {
+        id: `${Date.now()}`,
+        title,
+        completed: false,
+        createdAt,
+      },
+    ])
+  }
+
+  const handleToggleTodo = (todoId: string) => {
+    setTodos((currentTodos) =>
+      currentTodos.map((todo) =>
+        todo.id === todoId ? { ...todo, completed: !todo.completed } : todo,
+      ),
+    )
+  }
+
+  const handleUpdateTodo = (todoId: string, title: string) => {
+    setTodos((currentTodos) =>
+      currentTodos.map((todo) => (todo.id === todoId ? { ...todo, title } : todo)),
+    )
+  }
+
+  const handleDeleteTodo = (todoId: string) => {
+    setTodos((currentTodos) => currentTodos.filter((todo) => todo.id !== todoId))
+  }
+
+  return (
+    <section className={styles.weeklyCalendar} aria-label="주간 캘린더">
+      <WeekDayHeader days={days} />
+      {isTodoOpen ? (
+        <TodoPanel
+          days={days}
+          todos={todos}
+          onAddTodo={handleAddTodo}
+          onDeleteTodo={handleDeleteTodo}
+          onToggleTodo={handleToggleTodo}
+          onUpdateTodo={handleUpdateTodo}
+        />
+      ) : null}
+      <WeeklyGrid
+        days={days}
+        eventsByDate={eventsByDate}
+        selection={selection}
+        timeSlots={timeSlots}
+        onCreateEvent={handleCreateEvent}
+        onEditEvent={handleEditEvent}
+        onMoveEvent={handleMoveEvent}
+        onResizeEvent={handleResizeEvent}
+      />
+      {modalState ? (
+        <EventModal
+          key={
+            modalState.mode === 'edit'
+              ? modalState.event.id
+              : `${modalState.date}-${modalState.startTime}`
+          }
+          categories={calendarCategories}
+          defaultDate={modalState.mode === 'edit' ? modalState.event.date : modalState.date}
+          defaultEndTime={modalState.mode === 'edit' ? modalState.event.endTime : modalState.endTime}
+          defaultStartTime={
+            modalState.mode === 'edit' ? modalState.event.startTime : modalState.startTime
+          }
+          event={modalState.mode === 'edit' ? modalState.event : undefined}
+          getCategoryColor={getCategoryColor}
+          mode={modalState.mode}
+          onClose={handleCloseModal}
+          onDelete={handleDeleteEvent}
+          onSave={handleSaveEvent}
+        />
+      ) : null}
+    </section>
+  )
+}

--- a/src/components/calendar/weekly/WeeklyCalendar.tsx
+++ b/src/components/calendar/weekly/WeeklyCalendar.tsx
@@ -122,6 +122,10 @@ export default function WeeklyCalendar() {
     )
   }
 
+  const handleResizeEnd = () => {
+    setSelection(null)
+  }
+
   const handleDeleteEvent = () => {
     if (modalState?.mode !== 'edit') {
       return
@@ -189,6 +193,7 @@ export default function WeeklyCalendar() {
         onCreateEvent={handleCreateEvent}
         onEditEvent={handleEditEvent}
         onMoveEvent={handleMoveEvent}
+        onResizeEnd={handleResizeEnd}
         onResizeEvent={handleResizeEvent}
       />
       {modalState ? (

--- a/src/components/calendar/weekly/WeeklyGrid.tsx
+++ b/src/components/calendar/weekly/WeeklyGrid.tsx
@@ -1,0 +1,52 @@
+import type { CalendarDay, CalendarEvent } from '@/types/calendar'
+import DayColumn from './DayColumn'
+import TimeColumn from './TimeColumn'
+import styles from './weeklyCalendar.module.css'
+
+type WeeklyGridProps = {
+  days: CalendarDay[]
+  eventsByDate: Record<string, CalendarEvent[]>
+  selection: { date: string; startMinute: number; endMinute: number } | null
+  timeSlots: string[]
+  onCreateEvent: (day: CalendarDay, startMinute: number, endMinute: number) => void
+  onEditEvent: (event: CalendarEvent) => void
+  onMoveEvent: (
+    event: CalendarEvent,
+    nextDate: string,
+    startMinute: number,
+    endMinute: number,
+  ) => void
+  onResizeEvent: (event: CalendarEvent, startMinute: number, endMinute: number) => void
+}
+
+export default function WeeklyGrid({
+  days,
+  eventsByDate,
+  selection,
+  timeSlots,
+  onCreateEvent,
+  onEditEvent,
+  onMoveEvent,
+  onResizeEvent,
+}: WeeklyGridProps) {
+  return (
+    <div className={styles.weekGrid}>
+      <TimeColumn timeSlots={timeSlots} />
+      <div className={styles.dayColumns}>
+        {days.map((day) => (
+          <DayColumn
+            key={day.key}
+            day={day}
+            events={eventsByDate[day.key] ?? []}
+            selection={selection?.date === day.key ? selection : null}
+            timeSlots={timeSlots}
+            onCreateEvent={onCreateEvent}
+            onEditEvent={onEditEvent}
+            onMoveEvent={onMoveEvent}
+            onResizeEvent={onResizeEvent}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/calendar/weekly/WeeklyGrid.tsx
+++ b/src/components/calendar/weekly/WeeklyGrid.tsx
@@ -16,6 +16,7 @@ type WeeklyGridProps = {
     startMinute: number,
     endMinute: number,
   ) => void
+  onResizeEnd: () => void
   onResizeEvent: (event: CalendarEvent, startMinute: number, endMinute: number) => void
 }
 
@@ -27,6 +28,7 @@ export default function WeeklyGrid({
   onCreateEvent,
   onEditEvent,
   onMoveEvent,
+  onResizeEnd,
   onResizeEvent,
 }: WeeklyGridProps) {
   return (
@@ -43,6 +45,7 @@ export default function WeeklyGrid({
             onCreateEvent={onCreateEvent}
             onEditEvent={onEditEvent}
             onMoveEvent={onMoveEvent}
+            onResizeEnd={onResizeEnd}
             onResizeEvent={onResizeEvent}
           />
         ))}

--- a/src/components/calendar/weekly/weeklyCalendar.module.css
+++ b/src/components/calendar/weekly/weeklyCalendar.module.css
@@ -336,7 +336,7 @@
   font-size: var(--font-size-xs);
   font-weight: 800;
   pointer-events: none;
-  z-index: 2;
+  z-index: 4;
 }
 
 .eventBlock {
@@ -360,6 +360,7 @@
   box-shadow: var(--shadow-sm);
   cursor: grab;
   touch-action: none;
+  user-select: none;
   z-index: 3;
 }
 
@@ -386,10 +387,26 @@
 }
 
 .eventTime {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   font-weight: 700;
   line-height: var(--line-height-compact);
+  user-select: none;
+}
+
+.eventTimeDivider {
+  color: var(--color-text-subtle);
+}
+
+.activeResizeTime {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--space-5);
+  color: var(--color-important);
+  font-weight: 800;
 }
 
 .modalOverlay {

--- a/src/components/calendar/weekly/weeklyCalendar.module.css
+++ b/src/components/calendar/weekly/weeklyCalendar.module.css
@@ -1,0 +1,553 @@
+.weeklyCalendar {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  background: var(--color-surface);
+}
+
+.weekHeader,
+.weekGrid,
+.todoPanel {
+  min-width: var(--calendar-min-width);
+  display: grid;
+  grid-template-columns: var(--calendar-time-column-width) minmax(0, 1fr);
+}
+
+.weekHeader {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  min-height: calc(var(--space-10) + var(--space-6));
+  border-bottom: 1px solid var(--color-border-soft);
+  background: var(--color-surface);
+}
+
+.timeHeader {
+  border-right: 1px solid var(--color-border-soft);
+}
+
+.dayHeaderGrid,
+.dayColumns {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.dayHeaderCell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  border-right: 1px solid var(--color-border-soft);
+}
+
+.dayHeaderCell:last-child,
+.dayColumn:last-child {
+  border-right: 0;
+}
+
+.weekday {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+  line-height: var(--line-height-compact);
+}
+
+.dateNumber,
+.todayDate {
+  width: var(--space-8);
+  height: var(--space-8);
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  font-size: var(--font-size-sm);
+  font-weight: 800;
+  line-height: var(--line-height-compact);
+}
+
+.dateNumber {
+  color: var(--color-text);
+}
+
+.todayDate {
+  background: var(--color-brand);
+  color: var(--color-surface);
+}
+
+.todoPanel {
+  border-bottom: 1px solid var(--color-border-soft);
+  background: var(--color-cell-muted);
+}
+
+.todoPanelOffset {
+  border-right: 1px solid var(--color-border-soft);
+  background: var(--color-cell-muted);
+}
+
+.todoPanelContent {
+  min-width: 0;
+  padding: var(--space-2) 0;
+  background: var(--color-cell-muted);
+}
+
+.todoForm,
+.todoEditForm {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.todoForm input,
+.todoEditForm input {
+  min-width: 0;
+  flex: 1;
+  height: var(--space-8);
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  padding: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  outline: 0;
+}
+
+.todoForm input[type='checkbox'] {
+  width: var(--space-4);
+  height: var(--space-4);
+  flex: 0 0 auto;
+  accent-color: var(--color-text-subtle);
+}
+
+.todoForm input[type='checkbox']:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.todoForm input::placeholder {
+  color: var(--color-text-subtle);
+}
+
+.todoEditForm input:focus {
+  color: var(--color-text);
+}
+
+.todoDayGrid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0;
+  background: transparent;
+}
+
+.todoDayColumn {
+  min-width: 0;
+  min-height: calc(var(--space-10) * 3);
+  display: flex;
+  flex-direction: column;
+  padding: 0 var(--space-2);
+  border-right: 1px solid var(--color-border-soft);
+  background: transparent;
+}
+
+.todoDayColumn:last-child {
+  border-right: 0;
+}
+
+.todoList {
+  min-width: 0;
+  min-height: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.todoItem,
+.todoForm {
+  min-width: 0;
+  min-height: var(--space-8);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-bottom: 1px solid var(--color-border-soft);
+  background: transparent;
+}
+
+.todoForm {
+  margin-top: auto;
+  border-bottom: 0;
+}
+
+.todoCheckbox {
+  width: var(--space-4);
+  height: var(--space-4);
+  accent-color: var(--color-brand);
+}
+
+.todoTitle {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  overflow: hidden;
+  padding: 0;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+}
+
+.completedTodo {
+  color: var(--color-text-subtle);
+  text-decoration: line-through;
+}
+
+.todoDeleteButton {
+  width: var(--space-6);
+  height: var(--space-6);
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-subtle);
+  padding: 0;
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+  opacity: 0;
+}
+
+.todoSubmitButton {
+  width: var(--space-6);
+  height: var(--space-6);
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--color-brand);
+  border-radius: var(--radius-md);
+  background: var(--color-brand-soft);
+  color: var(--color-brand-strong);
+  padding: 0;
+}
+
+.todoSubmitButton:hover {
+  border-color: var(--color-brand-strong);
+  background: var(--color-active);
+}
+
+.todoSubmitButton::before {
+  content: '';
+  width: calc(var(--space-3) - 2px);
+  height: calc(var(--space-2) - 2px);
+  border-left: 2px solid var(--color-brand-strong);
+  border-bottom: 2px solid var(--color-brand-strong);
+  transform: translateY(-1px) rotate(-45deg);
+}
+
+.todoItem:hover .todoDeleteButton,
+.todoDeleteButton:focus {
+  opacity: 1;
+}
+
+.todoDeleteButton:hover {
+  background: var(--color-hover);
+  color: var(--color-important);
+}
+
+.weekGrid {
+  flex: 1;
+  min-height: calc(var(--calendar-hour-height) * 24);
+}
+
+.timeColumn {
+  border-right: 1px solid var(--color-border-soft);
+  background: var(--color-surface);
+}
+
+.timeSlot {
+  height: var(--calendar-hour-height);
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--space-1) var(--space-3) 0 0;
+  border-bottom: 1px solid var(--color-border-soft);
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  line-height: var(--line-height-compact);
+}
+
+.dayColumn {
+  position: relative;
+  min-width: 0;
+  min-height: calc(var(--calendar-hour-height) * 24);
+  border-right: 1px solid var(--color-border-soft);
+  background: var(--color-surface);
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.hourLines {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-rows: repeat(24, var(--calendar-hour-height));
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hourLine {
+  border-bottom: 1px solid var(--color-border-soft);
+}
+
+.hourHoverGrid {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-rows: repeat(24, var(--calendar-hour-height));
+  z-index: 1;
+}
+
+.hourHoverSlot {
+  min-width: 0;
+  border: 0;
+  border-bottom: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.hourHoverSlot:hover {
+  background: var(--color-hover);
+}
+
+.selectionBlock {
+  position: absolute;
+  top: var(--selection-offset);
+  left: var(--space-1);
+  right: var(--space-1);
+  height: max(var(--selection-height), calc(var(--space-8) + var(--space-2)));
+  display: flex;
+  align-items: flex-start;
+  padding: var(--space-2);
+  border: 1px solid var(--color-brand);
+  border-radius: var(--radius-md);
+  background: var(--color-brand-soft);
+  color: var(--color-brand-strong);
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.eventBlock {
+  position: absolute;
+  top: var(--event-offset);
+  left: var(--space-1);
+  right: var(--space-1);
+  height: max(var(--event-height), calc(var(--space-8) + var(--space-2)));
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--event-color, var(--color-brand)) 35%, var(--color-surface));
+  border-left: var(--space-1) solid var(--event-color, var(--color-brand));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--event-color, var(--color-brand)) 12%, var(--color-surface));
+  color: var(--color-text);
+  padding: var(--space-2);
+  text-align: left;
+  box-shadow: var(--shadow-sm);
+  cursor: grab;
+  touch-action: none;
+  z-index: 3;
+}
+
+.eventBlock:hover {
+  background: color-mix(in srgb, var(--event-color, var(--color-brand)) 18%, var(--color-surface));
+}
+
+.eventBlock[data-cursor-mode='resize'] {
+  cursor: ns-resize;
+}
+
+.eventBlock:active {
+  cursor: grabbing;
+}
+
+.eventTitle {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-sm);
+  font-weight: 800;
+  line-height: var(--line-height-compact);
+}
+
+.eventTime {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  line-height: var(--line-height-compact);
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal);
+  display: grid;
+  place-items: center;
+  padding: var(--space-6);
+  background: var(--color-overlay);
+}
+
+.eventModal {
+  width: min(var(--calendar-modal-width), 100%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-popover);
+}
+
+.modalHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.modalHeader h2,
+.modalEyebrow {
+  margin: 0;
+}
+
+.modalHeader h2 {
+  color: var(--color-text);
+  font-size: var(--font-size-lg);
+  font-weight: 800;
+  line-height: var(--line-height-normal);
+}
+
+.modalEyebrow {
+  color: var(--color-brand-strong);
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+  line-height: var(--line-height-compact);
+}
+
+.closeButton {
+  width: var(--space-8);
+  height: var(--space-8);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 800;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 750;
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  outline: 0;
+}
+
+.field input,
+.field select {
+  height: var(--space-10);
+}
+
+.field textarea {
+  min-height: calc(var(--space-10) * 2);
+  padding-top: var(--space-3);
+  resize: vertical;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  border-color: var(--color-brand);
+  box-shadow: 0 0 0 var(--space-1) var(--color-brand-soft);
+}
+
+.timeFields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.modalActions,
+.actionGroup {
+  display: flex;
+  align-items: center;
+}
+
+.modalActions {
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+}
+
+.actionGroup {
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+.primaryButton,
+.secondaryButton,
+.deleteButton {
+  height: var(--space-10);
+  border-radius: var(--radius-md);
+  padding: 0 var(--space-4);
+  font-size: var(--font-size-base);
+  font-weight: 750;
+}
+
+.primaryButton {
+  border: 0;
+  background: var(--color-brand);
+  color: var(--color-surface);
+}
+
+.secondaryButton,
+.deleteButton {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.secondaryButton {
+  color: var(--color-text-muted);
+}
+
+.deleteButton {
+  color: var(--color-important);
+}
+
+@media (max-width: 980px) {
+  .todoDayGrid {
+    grid-template-columns: repeat(7, minmax(112px, 1fr));
+    overflow-x: auto;
+  }
+}

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import type { CalendarCategory, CalendarDay, CalendarEvent } from '@/types/calendar'
+import type { CalendarCategory, CalendarDay, CalendarEvent, CalendarTodo } from '@/types/calendar'
 
 export const calendarCategories: CalendarCategory[] = [
   { id: 'work', label: '업무', color: 'var(--color-work)' },
@@ -75,6 +75,93 @@ export const sampleEvents: CalendarEvent[] = [
   },
 ]
 
+export const sampleTodos: CalendarTodo[] = [
+  {
+    id: 'todo-1',
+    title: '자바 1강 신청',
+    completed: false,
+    createdAt: '2026-06-01',
+  },
+  {
+    id: 'todo-2',
+    title: '주간 일정 정리',
+    completed: false,
+    createdAt: '2026-06-01',
+  },
+  {
+    id: 'todo-3',
+    title: '캘린더 QA 체크',
+    completed: true,
+    createdAt: '2026-06-02',
+  },
+  {
+    id: 'todo-4',
+    title: '디자인 토큰 확인',
+    completed: false,
+    createdAt: '2026-06-02',
+  },
+  {
+    id: 'todo-5',
+    title: '프론트엔드 변수 공부',
+    completed: true,
+    createdAt: '2026-06-03',
+  },
+  {
+    id: 'todo-6',
+    title: 'Todo Panel 피드백 반영',
+    completed: false,
+    createdAt: '2026-06-03',
+  },
+  {
+    id: 'todo-7',
+    title: '위클리 뷰 구조 검토',
+    completed: false,
+    createdAt: '2026-06-04',
+  },
+  {
+    id: 'todo-8',
+    title: '일정 모달 플로우 점검',
+    completed: false,
+    createdAt: '2026-06-04',
+  },
+  {
+    id: 'todo-9',
+    title: '메인페이지 기획',
+    completed: false,
+    createdAt: '2026-06-05',
+  },
+  {
+    id: 'todo-10',
+    title: '회의 자료 정리',
+    completed: true,
+    createdAt: '2026-06-05',
+  },
+  {
+    id: 'todo-11',
+    title: '주말 루틴 작성',
+    completed: false,
+    createdAt: '2026-06-06',
+  },
+  {
+    id: 'todo-12',
+    title: '다음 주 작업 메모',
+    completed: false,
+    createdAt: '2026-06-06',
+  },
+  {
+    id: 'todo-13',
+    title: '월요일 우선순위 정리',
+    completed: false,
+    createdAt: '2026-06-07',
+  },
+  {
+    id: 'todo-14',
+    title: '개인 일정 확인',
+    completed: true,
+    createdAt: '2026-06-07',
+  },
+]
+
 export function getMonthDays(baseDate = '2026-06-01') {
   const month = dayjs(baseDate).startOf('month')
   const start = month.startOf('week')
@@ -91,6 +178,63 @@ export function getMonthDays(baseDate = '2026-06-01') {
       isToday: date.isSame(today, 'day'),
     }
   })
+}
+
+export function getWeekDays(baseDate = '2026-06-05') {
+  const start = dayjs(baseDate).startOf('week').add(1, 'day')
+  const today = dayjs()
+
+  return Array.from({ length: 7 }, (_, index): CalendarDay => {
+    const date = start.add(index, 'day')
+
+    return {
+      key: date.format('YYYY-MM-DD'),
+      date,
+      dayNumber: date.date(),
+      isCurrentMonth: date.month() === dayjs(baseDate).month(),
+      isToday: date.isSame(today, 'day'),
+    }
+  })
+}
+
+export function getTimeSlots() {
+  return Array.from({ length: 24 }, (_, hour) => `${String(hour).padStart(2, '0')}:00`)
+}
+
+export function clampMinute(minute: number) {
+  return Math.max(0, Math.min(24 * 60, minute))
+}
+
+export function snapMinute(minute: number, step = 30) {
+  return clampMinute(Math.round(minute / step) * step)
+}
+
+export function timeToMinutes(time: string) {
+  const [hour, minute] = time.split(':').map(Number)
+  return hour * 60 + minute
+}
+
+export function minutesToTime(totalMinutes: number) {
+  const clampedMinutes = clampMinute(totalMinutes)
+  const hour = Math.floor(clampedMinutes / 60)
+  const minute = clampedMinutes % 60
+
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+}
+
+export function getMinuteFromPointer(clientY: number, rect: DOMRect, step = 30) {
+  const offsetY = clientY - rect.top
+  return snapMinute((offsetY / rect.height) * 24 * 60, step)
+}
+
+export function getEventOffset(startTime: string) {
+  return timeToMinutes(startTime)
+}
+
+export function getEventDuration(startTime: string, endTime: string) {
+  const start = timeToMinutes(startTime)
+  const end = timeToMinutes(endTime)
+  return Math.max(end - start, 30)
 }
 
 export function getCategoryById(categoryId: string) {

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -8,14 +8,41 @@ export type CalendarCategory = {
   color: string
 }
 
+export type WeekDayCode = 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU'
+
+export type RecurrenceFrequency =
+  | 'NONE'
+  | 'DAILY'
+  | 'WEEKLY'
+  | 'WEEKDAYS'
+  | 'MONTHLY'
+  | 'CUSTOM'
+
+export type RecurrenceRule = {
+  frequency: RecurrenceFrequency
+  interval?: number
+  byWeekDay?: WeekDayCode[]
+  until?: string
+  count?: number
+}
+
 export type CalendarEvent = {
   id: string
   title: string
+  description?: string
   date: string
   startTime: string
   endTime: string
   categoryId: string
   color: string
+  recurrenceRule?: RecurrenceRule
+}
+
+export type CalendarTodo = {
+  id: string
+  title: string
+  completed: boolean
+  createdAt: string
 }
 
 export type CalendarDay = {


### PR DESCRIPTION
## 📣 Related Issue
- #4

## 📝 Summary
- Google Calendar 스타일의 주간 캘린더 뷰 구현
- 7일 기준 시간축 기반 Weekly Grid 구성
- 기존 Top Nav의 `주` 버튼과 Weekly View 연결
- Todo 버튼 및 요일별 Todo 영역 구현
- Todo 추가, 수정, 삭제, 완료 체크 기능 구현
- 시간 그리드 드래그 기반 일정 생성 기능 구현
- 일정 클릭 시 수정 모달 구현
- 일정 삭제 기능 구현
- 일정 Drag & Drop 이동 기능 구현
- 일정 상단/하단 Resize 기능 구현
- 클릭 생성과 드래그 생성을 분리하여 UX 개선
- Resize 중 변경되는 시작/종료 시간 실시간 강조 표시
- 일정 설명 및 반복 설정 데이터 구조 추가
- Weekly 관련 컴포넌트 분리

## 🙏 PR point
- 전체 구현 과정 Codex AI를 활용하여 진행
- Weekly Calendar 컴포넌트 구조 설계 및 코드 AI 생성
- Drag & Drop, Resize, Todo Panel UX 구현 AI 생성
- 현재 일정과 Todo 데이터는 백엔드 연동 전 mock data/local state 기반
- 추가 패키지 없이 pointer event 기반으로 구현

## 📬 Reference
- Codex AI
- Google Calendar Weekly View