### PR TITLE
[✨Feat/#14] 메인 페이지 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# 쿼리 파일을 포함한 무시된 디폴트 폴더
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/Dayleaf-FE.iml
+++ b/.idea/Dayleaf-FE.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,61 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <HTMLCodeStyleSettings>
+      <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+    </HTMLCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
+      <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="WhenMultiline" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="WhenMultiline" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </TypeScriptCodeStyleSettings>
+    <VueCodeStyleSettings>
+      <option name="INTERPOLATION_NEW_LINE_AFTER_START_DELIMITER" value="false" />
+      <option name="INTERPOLATION_NEW_LINE_BEFORE_END_DELIMITER" value="false" />
+    </VueCodeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Vue">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Dayleaf-FE.iml" filepath="$PROJECT_DIR$/.idea/Dayleaf-FE.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
+    <option name="myRunOnSave" value="true" />
+    <option name="codeStyleSettingsModifierEnabled" value="false" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,51 @@
-export default function MainPage() {
+// src/app/page.tsx
+//
+// 메인 페이지(대시보드).
+//
+// 설계 원칙:
+//   - 서버 컴포넌트로 유지하고, 데이터는 lib/api/* 패칭 함수에서 가져온다.
+//   - WeatherBriefing: 내부에서 getTodayBriefing()을 직접 await하는 async 서버 컴포넌트
+//   - TodaySchedule / Bookshelf: 순수 표시용 서버 컴포넌트
+//   - TodayProgress: 체크박스 토글 상태 때문에 내부적으로만 'use client'
+//
+// 데이터 흐름:
+//   서버 컴포넌트에서 오늘 날짜를 기준으로 일정·진행률을 패칭해 props로 주입한다.
+//   추후 BE 엔드포인트가 확정되면 lib/api/* 함수만 교체한다.
+
+import MainHeader from '@/components/main/MainHeader'
+import WeatherBriefing from '@/components/main/WeatherBriefing'
+import TodaySchedule from '@/components/main/TodaySchedule'
+import TodayProgress from '@/components/main/TodayProgress'
+import Bookshelf from '@/components/main/Bookshelf'
+import { archivedBooks, bookshelfPots, getTodayIso } from '@/lib/main'
+import { getTodaySchedule } from '@/lib/api/schedule'
+import { getTodayProgress } from '@/lib/api/progress'
+import styles from '@/components/main/main.module.css'
+
+export default async function MainPage() {
+  const today = getTodayIso() // 'YYYY-MM-DD'
+
+  // 서버에서 오늘 날짜 기준 데이터 패칭.
+  // Promise.all로 병렬 실행해 렌더링 시간을 최소화한다.
+  const [schedule, progress] = await Promise.all([
+    getTodaySchedule(today),
+    getTodayProgress(today),
+  ])
+
   return (
-    <main>
-      <h1>메인 페이지</h1>
+    <main className={styles.page}>
+      {/* 날짜 헤더 */}
+      <MainHeader todayIso={today} />
+
+      {/* 상단 3분할: 날씨 / 일정 / 진행률 */}
+      <div className={styles.topGrid}>
+        <WeatherBriefing />
+        <TodaySchedule items={schedule} />
+        <TodayProgress items={progress} />
+      </div>
+
+      {/* 하단 책장 */}
+      <Bookshelf pots={bookshelfPots} books={archivedBooks} />
     </main>
   )
 }

--- a/src/components/main/Bookshelf.tsx
+++ b/src/components/main/Bookshelf.tsx
@@ -1,0 +1,79 @@
+// src/components/main/Bookshelf.tsx
+//
+// 기록 책장 (시그니처 영역).
+//  - 상단: growth에 따라 자라는 화분 4개 (전체/루틴/일기/투두)
+//  - 하단: 과거 기록이 책으로 꽂힘. completion이 낮을수록 "빛바랜 종이"처럼 옅게.
+//
+// 정적 표시이므로 서버 컴포넌트로 유지한다.
+// 추후 DailySummary API가 생기면 props를 서버에서 패칭해 주입한다.
+
+import type { CSSProperties } from 'react'
+import type { ArchivedBook, BookshelfPot } from '@/types/main'
+import PlantPot from './PlantPot'
+import styles from './main.module.css'
+
+type BookshelfProps = {
+  pots: BookshelfPot[]
+  books: ArchivedBook[]
+}
+
+// 책 높이: completion에 비례 (최소 44, 최대 84px)
+function bookHeight(completion: number): number {
+  return 44 + Math.round(completion * 40)
+}
+
+// 책등 색: completion이 높을수록 진한 브랜드색, 낮을수록 옅어진다("빛바램")
+function bookColor(completion: number): string {
+  const mix = Math.round(completion * 100)
+  return `color-mix(in srgb, var(--color-brand) ${mix}%, var(--color-surface-muted))`
+}
+
+export default function Bookshelf({ pots, books }: BookshelfProps) {
+  return (
+    <section className={styles.bookshelf} aria-label="기록 책장">
+      <div className={styles.bookshelfHeader}>
+        <h2 className={styles.bookshelfTitle}>나의 기록 책장</h2>
+        <span className={styles.bookshelfHint}>
+          매일의 기록이 모여 한 권의 책이 됩니다
+        </span>
+      </div>
+
+      {/* 화분 줄 */}
+      <div className={styles.shelfTop}>
+        {pots.map((pot) => (
+          <div key={pot.id} className={styles.pot}>
+            <span className={styles.potArt}>
+              <PlantPot pot={pot} />
+            </span>
+            <span className={styles.potLabel}>{pot.label}</span>
+            <span className={styles.potGrowth}>
+              {Math.round(pot.growth * 100)}%
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* 선반 판자 */}
+      <div className={styles.shelfPlank} aria-hidden="true" />
+
+      {/* 과거 기록 책들 */}
+      <div className={styles.shelfBooks}>
+        {books.map((book) => (
+          <span
+            key={book.date}
+            className={styles.book}
+            title={`${book.date} · 완료율 ${Math.round(book.completion * 100)}%`}
+            style={
+              {
+                height: `${bookHeight(book.completion)}px`,
+                '--book-color': bookColor(book.completion),
+              } as CSSProperties
+            }
+          >
+            <span className={styles.bookSpine}>{book.spineLabel}</span>
+          </span>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/main/MainHeader.tsx
+++ b/src/components/main/MainHeader.tsx
@@ -1,0 +1,20 @@
+// src/components/main/MainHeader.tsx
+//
+// 메인 페이지 날짜 헤더.
+// 정적 표시만 하므로 서버 컴포넌트로 유지한다.
+
+import { formatKoreanDate } from '@/lib/main'
+import styles from './main.module.css'
+
+type MainHeaderProps = {
+  todayIso: string // 'YYYY-MM-DD'
+}
+
+export default function MainHeader({ todayIso }: MainHeaderProps) {
+  return (
+    <header className={styles.header}>
+      <p className={styles.eyebrow}>오늘의 기록</p>
+      <h1 className={styles.dateTitle}>{formatKoreanDate(todayIso)}</h1>
+    </header>
+  )
+}

--- a/src/components/main/PlantPot.tsx
+++ b/src/components/main/PlantPot.tsx
@@ -1,0 +1,83 @@
+// src/components/main/PlantPot.tsx
+//
+// 활동량(growth)에 따라 새싹이 자라는 화분 SVG.
+// growth(0.0~1.0)에 비례해 줄기 높이와 잎 단계(1~3쌍)가 달라진다.
+// 서버 컴포넌트로 사용 가능 (순수 표시용).
+
+import type { BookshelfPot } from '@/types/main'
+
+type PlantPotProps = {
+  pot: BookshelfPot
+}
+
+export default function PlantPot({ pot }: PlantPotProps) {
+  // 줄기 높이: 최소 12, 최대 56 (대비를 키워 성장 차이를 또렷하게)
+  const stemHeight = 12 + Math.round(pot.growth * 44)
+  const stemTopY = 70 - stemHeight
+
+  // 잎 단계: growth 구간에 따라 1~3쌍
+  const leafStage = pot.growth >= 0.66 ? 3 : pot.growth >= 0.33 ? 2 : 1
+
+  return (
+    <svg
+      width="84"
+      height="104"
+      viewBox="0 0 84 104"
+      fill="none"
+      aria-hidden="true"
+    >
+      {/* 줄기 */}
+      <line
+        x1="42"
+        y1="70"
+        x2="42"
+        y2={stemTopY}
+        stroke="var(--color-routine)"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+
+      {/* 잎: 단계별로 좌우 한 쌍씩 추가 */}
+      {Array.from({ length: leafStage }).map((_, index) => {
+        const y = stemTopY + 8 + index * ((stemHeight - 8) / leafStage)
+        return (
+          <g key={index}>
+            <path
+              d={`M42 ${y} q -14 -6 -18 -16 q 14 2 18 12`}
+              fill="var(--color-routine)"
+              opacity={0.85}
+            />
+            <path
+              d={`M42 ${y + 4} q 14 -6 18 -16 q -14 2 -18 12`}
+              fill="var(--color-brand)"
+              opacity={0.85}
+            />
+          </g>
+        )
+      })}
+
+      {/* 새싹 꼭대기 잎 */}
+      <path
+        d={`M42 ${stemTopY} q -5 -8 0 -14 q 5 6 0 14`}
+        fill="var(--color-brand-strong)"
+      />
+
+      {/* 화분 본체 (사다리꼴) */}
+      <path
+        d="M26 70 h32 l-4 26 a4 4 0 0 1 -4 3 h-16 a4 4 0 0 1 -4 -3 z"
+        fill="var(--color-personal)"
+        opacity="0.9"
+      />
+      {/* 화분 테두리(흙 라인) */}
+      <rect
+        x="24"
+        y="66"
+        width="36"
+        height="8"
+        rx="3"
+        fill="var(--color-important)"
+        opacity="0.55"
+      />
+    </svg>
+  )
+}

--- a/src/components/main/TodayProgress.tsx
+++ b/src/components/main/TodayProgress.tsx
@@ -1,0 +1,96 @@
+// src/components/main/TodayProgress.tsx
+//
+// 오늘 기준 루틴+투두 진행률 패널.
+//
+// 설계 의도:
+//   - 체크박스 토글에 로컬 상태가 필요하므로 이 컴포넌트만 'use client'로 분리한다.
+//   - ProgressItem의 source 필드로 루틴(ROUTINE)과 투두(TODO)를 구분해 태그 표시.
+//   - BE 연동 후에는 done 상태 토글 시 TodoExecution API를 호출하는 로직을 추가한다.
+//     (현재는 로컬 상태만 변경)
+
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { ProgressItem } from '@/types/main'
+import styles from './main.module.css'
+
+type TodayProgressProps = {
+  items: ProgressItem[]
+}
+
+// BE의 SourceType(MANUAL | SCHEDULE | REPEAT)에서 파생.
+// 표시용 한국어 라벨.
+const SOURCE_LABEL: Record<ProgressItem['source'], string> = {
+  ROUTINE: '루틴',
+  TODO: '투두',
+}
+
+export default function TodayProgress({ items }: TodayProgressProps) {
+  const [progress, setProgress] = useState<ProgressItem[]>(items)
+
+  const { doneCount, rate } = useMemo(() => {
+    const done = progress.filter((item: ProgressItem) => item.done).length
+    const total = progress.length
+    return {
+      doneCount: done,
+      rate: total === 0 ? 0 : Math.round((done / total) * 100),
+    }
+  }, [progress])
+
+  const toggleItem = (id: string) => {
+    setProgress((current: ProgressItem[]) =>
+      current.map((item: ProgressItem) =>
+        item.id === id ? { ...item, done: !item.done } : item
+      )
+    )
+    // TODO: BE TodoExecution API 연동 후 완료 상태 서버 동기화 추가
+    //   ex) await apiClient.patch(`/api/todo-executions/${id}/toggle`)
+  }
+
+  return (
+    <section className={styles.card} aria-label="오늘 기준 루틴과 투두 진행률">
+      <div className={styles.progressHeader}>
+        <p className={styles.cardLabel}>오늘 기준 루틴+투두 진행률</p>
+        <span className={styles.progressRate}>{rate}%</span>
+      </div>
+
+      <div
+        className={styles.progressBar}
+        role="progressbar"
+        aria-valuenow={rate}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`완료 ${doneCount}건 / 전체 ${progress.length}건`}
+      >
+        <span className={styles.progressFill} style={{ width: `${rate}%` }} />
+      </div>
+
+      <div className={styles.progressList}>
+        {progress.map((item: ProgressItem) => (
+          <button
+            key={item.id}
+            type="button"
+            className={styles.progressItem}
+            onClick={() => toggleItem(item.id)}
+            aria-pressed={item.done}
+          >
+            <span
+              className={`${styles.checkbox} ${item.done ? styles.checkboxChecked : ''}`}
+              aria-hidden="true"
+            >
+              {item.done ? '✓' : ''}
+            </span>
+            <span
+              className={`${styles.progressItemTitle} ${item.done ? styles.progressItemDone : ''}`}
+            >
+              {item.title}
+            </span>
+            <span className={styles.sourceTag}>
+              {SOURCE_LABEL[item.source]}
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/main/TodaySchedule.tsx
+++ b/src/components/main/TodaySchedule.tsx
@@ -1,0 +1,57 @@
+// src/components/main/TodaySchedule.tsx
+//
+// 오늘 일정 카드.
+// BE의 ScheduleResponse를 TodayScheduleItem으로 변환한 데이터를 받아 표시한다.
+// 정적 표시이므로 서버 컴포넌트로 유지한다.
+//
+// BE ScheduleResponse의 시간 형태: 'HH:mm:ss' (LocalTime → Jackson 직렬화)
+// → formatTime() 유틸로 'HH:mm'으로 잘라 표시한다.
+
+import type { CSSProperties } from 'react'
+import { formatTime } from '@/lib/api/schedule'
+import type { TodayScheduleItem } from '@/types/main'
+import styles from './main.module.css'
+
+type TodayScheduleProps = {
+  items: TodayScheduleItem[]
+}
+
+function formatRange(
+  startTime: string | null,
+  endTime: string | null,
+  allDay: boolean
+): string {
+  if (allDay) return '종일'
+  const start = formatTime(startTime)
+  const end = formatTime(endTime)
+  return end ? `${start} – ${end}` : start
+}
+
+export default function TodaySchedule({ items }: TodayScheduleProps) {
+  return (
+    <section className={styles.card} aria-label="오늘 일정">
+      <p className={styles.cardLabel}>오늘 일정</p>
+
+      {items.length === 0 ? (
+        <p className={styles.emptyText}>오늘은 등록된 일정이 없어요.</p>
+      ) : (
+        <div className={styles.scheduleList}>
+          {items.map((item) => (
+            <div key={item.nodeId} className={styles.scheduleItem}>
+              <span
+                className={styles.scheduleDot}
+                style={{ '--event-color': item.color } as CSSProperties}
+              />
+              <div className={styles.scheduleBody}>
+                <span className={styles.scheduleTitle}>{item.title}</span>
+                <span className={styles.scheduleTime}>
+                  {formatRange(item.startTime, item.endTime, item.allDay)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/main/WeatherBriefing.tsx
+++ b/src/components/main/WeatherBriefing.tsx
@@ -1,0 +1,56 @@
+// src/components/main/WeatherBriefing.tsx
+//
+// 사서 '리프'의 날씨 브리핑 카드.
+// async 서버 컴포넌트로 두어, getTodayBriefing()을 서버에서 호출한다.
+// BE 엔드포인트 확정 후 lib/api/weather.ts의 함수만 교체하면 이 컴포넌트는 변경되지 않는다.
+
+import {
+  getClothingLabel,
+  getTodayBriefing,
+  getWeatherLabel,
+} from '@/lib/api/weather'
+import WeatherIcon from './WeatherIcon'
+import styles from './main.module.css'
+
+export default async function WeatherBriefing() {
+  const briefing = await getTodayBriefing()
+
+  return (
+    <section
+      className={`${styles.card} ${styles.weatherCard}`}
+      aria-label="오늘 날씨"
+    >
+      <p className={styles.cardLabel}>오늘 날씨</p>
+
+      <div className={styles.weatherTop}>
+        <div className={styles.weatherIcon}>
+          <WeatherIcon code={briefing.iconCode} />
+        </div>
+        <div className={styles.weatherMeta}>
+          <span className={styles.weatherCondition}>
+            {getWeatherLabel(briefing.iconCode)}
+          </span>
+          <span className={styles.weatherSub}>
+            사서 리프가 전하는 오늘의 한 마디
+          </span>
+        </div>
+      </div>
+
+      {/* 사서 '리프'의 브리핑 메시지 — 인용구처럼 표현 */}
+      <blockquote className={styles.briefing}>
+        {briefing.message}
+        <cite className={styles.briefingSign}>— 리프</cite>
+      </blockquote>
+
+      {briefing.clothing.length > 0 ? (
+        <div className={styles.clothingRow} aria-label="추천 의류">
+          {briefing.clothing.map((code) => (
+            <span key={code} className={styles.clothingChip}>
+              {getClothingLabel(code)}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/components/main/WeatherIcon.tsx
+++ b/src/components/main/WeatherIcon.tsx
@@ -1,0 +1,155 @@
+// src/components/main/WeatherIcon.tsx
+//
+// WeatherIconCode를 인라인 SVG 아이콘으로 렌더링한다.
+// 외부 아이콘 라이브러리를 사용하지 않고 기존 코드 스타일을 따른다.
+// 색은 currentColor를 사용해, 부모에서 color 토큰으로 제어한다.
+
+import type { WeatherIconCode } from '@/types/weather'
+
+type WeatherIconProps = {
+  code: WeatherIconCode
+  size?: number
+}
+
+export default function WeatherIcon({ code, size = 56 }: WeatherIconProps) {
+  const common = {
+    width: size,
+    height: size,
+    viewBox: '0 0 48 48',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-hidden': true,
+  }
+
+  switch (code) {
+    case 'SUNNY':
+      return (
+        <svg {...common}>
+          <circle cx="24" cy="24" r="9" fill="currentColor" stroke="none" />
+          <line x1="24" y1="4" x2="24" y2="10" />
+          <line x1="24" y1="38" x2="24" y2="44" />
+          <line x1="4" y1="24" x2="10" y2="24" />
+          <line x1="38" y1="24" x2="44" y2="24" />
+          <line x1="10" y1="10" x2="14" y2="14" />
+          <line x1="34" y1="34" x2="38" y2="38" />
+          <line x1="38" y1="10" x2="34" y2="14" />
+          <line x1="14" y1="34" x2="10" y2="38" />
+        </svg>
+      )
+    case 'PARTLY_CLOUDY':
+      return (
+        <svg {...common}>
+          <circle cx="18" cy="16" r="6" fill="currentColor" stroke="none" />
+          <line x1="18" y1="4" x2="18" y2="7" />
+          <line x1="6" y1="16" x2="9" y2="16" />
+          <line x1="9" y1="7" x2="11" y2="9" />
+          <path
+            d="M16 34h16a6 6 0 0 0 0-12 8 8 0 0 0-15-2 5 5 0 0 0-1 14z"
+            fill="currentColor"
+            stroke="none"
+            opacity="0.85"
+          />
+        </svg>
+      )
+    case 'CLOUDY':
+    case 'FOGGY':
+      return (
+        <svg {...common}>
+          <path
+            d="M15 32h18a7 7 0 0 0 0-14 9 9 0 0 0-17-2 6 6 0 0 0-1 16z"
+            fill="currentColor"
+            stroke="none"
+            opacity="0.85"
+          />
+          {code === 'FOGGY' ? (
+            <g opacity="0.6">
+              <line x1="12" y1="38" x2="32" y2="38" />
+              <line x1="16" y1="42" x2="36" y2="42" />
+            </g>
+          ) : null}
+        </svg>
+      )
+    case 'RAINY':
+    case 'HEAVY_RAIN':
+      return (
+        <svg {...common}>
+          <path
+            d="M15 26h18a7 7 0 0 0 0-14 9 9 0 0 0-17-2 6 6 0 0 0-1 16z"
+            fill="currentColor"
+            stroke="none"
+            opacity="0.85"
+          />
+          <line x1="17" y1="32" x2="15" y2="40" />
+          <line x1="24" y1="32" x2="22" y2="40" />
+          <line x1="31" y1="32" x2="29" y2="40" />
+          {code === 'HEAVY_RAIN' ? (
+            <>
+              <line x1="20" y1="34" x2="18" y2="42" />
+              <line x1="27" y1="34" x2="25" y2="42" />
+            </>
+          ) : null}
+        </svg>
+      )
+    case 'SNOWY':
+    case 'HEAVY_SNOW':
+      return (
+        <svg {...common}>
+          <path
+            d="M15 26h18a7 7 0 0 0 0-14 9 9 0 0 0-17-2 6 6 0 0 0-1 16z"
+            fill="currentColor"
+            stroke="none"
+            opacity="0.85"
+          />
+          <circle cx="18" cy="36" r="1.6" fill="currentColor" stroke="none" />
+          <circle cx="24" cy="40" r="1.6" fill="currentColor" stroke="none" />
+          <circle cx="30" cy="36" r="1.6" fill="currentColor" stroke="none" />
+        </svg>
+      )
+    case 'THUNDERSTORM':
+      return (
+        <svg {...common}>
+          <path
+            d="M15 26h18a7 7 0 0 0 0-14 9 9 0 0 0-17-2 6 6 0 0 0-1 16z"
+            fill="currentColor"
+            stroke="none"
+            opacity="0.85"
+          />
+          <path
+            d="M25 30l-6 8h5l-2 6 7-9h-5z"
+            fill="currentColor"
+            stroke="none"
+          />
+        </svg>
+      )
+    case 'YELLOW_DUST':
+      return (
+        <svg {...common}>
+          <circle
+            cx="24"
+            cy="20"
+            r="8"
+            fill="currentColor"
+            stroke="none"
+            opacity="0.7"
+          />
+          <g opacity="0.6">
+            <line x1="12" y1="34" x2="36" y2="34" />
+            <line x1="14" y1="39" x2="34" y2="39" />
+            <line x1="16" y1="44" x2="32" y2="44" />
+          </g>
+        </svg>
+      )
+    case 'TYPHOON':
+      return (
+        <svg {...common}>
+          <path d="M24 10a14 14 0 1 1-13 9c2 6 9 8 14 5s6-10 1-13a8 8 0 0 0-9 2" />
+          <circle cx="24" cy="24" r="3" fill="currentColor" stroke="none" />
+        </svg>
+      )
+    default:
+      return null
+  }
+}

--- a/src/components/main/main.module.css
+++ b/src/components/main/main.module.css
@@ -1,0 +1,436 @@
+/* src/components/main/main.module.css
+ *
+ * 메인 페이지 전용 스타일.
+ * globals.css의 디자인 토큰(--color-*, --space-*, --radius-* 등)만 사용한다.
+ * 새로운 색상 값(HEX 등)을 추가하지 않는다. */
+
+.page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-8);
+    padding: var(--space-8) var(--space-10);
+    background: var(--color-bg);
+    color: var(--color-text);
+}
+
+/* ── 날짜 헤더 ─────────────────────────────────────────── */
+.header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.eyebrow {
+    margin: 0;
+    color: var(--color-brand-strong);
+    font-size: var(--font-size-xs);
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.dateTitle {
+    margin: 0;
+    color: var(--color-text);
+    font-size: var(--font-size-xl);
+    font-weight: 800;
+    letter-spacing: -0.01em;
+}
+
+/* ── 상단 3분할 그리드 (날씨 / 일정 / 진행률) ──────────── */
+.topGrid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) minmax(0, 1fr);
+    gap: var(--space-5);
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-6);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-sm);
+}
+
+.cardLabel {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 800;
+    letter-spacing: 0.04em;
+}
+
+/* ── 날씨 브리핑 카드 ─────────────────────────────────── */
+.weatherCard {
+    background: linear-gradient(
+            160deg,
+            var(--color-brand-soft) 0%,
+            var(--color-surface) 70%
+    );
+}
+
+.weatherTop {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.weatherIcon {
+    display: grid;
+    place-items: center;
+    width: 72px;
+    height: 72px;
+    flex: 0 0 auto;
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    color: var(--color-brand);
+    box-shadow: var(--shadow-sm);
+}
+
+.weatherMeta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.weatherCondition {
+    color: var(--color-text);
+    font-size: var(--font-size-lg);
+    font-weight: 800;
+}
+
+.weatherSub {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+}
+
+/* 사서 리프의 인용구 카드 */
+.briefing {
+    position: relative;
+    margin: 0;
+    padding: var(--space-3) 0 var(--space-3) var(--space-4);
+    border-left: 3px solid var(--color-brand);
+    color: var(--color-text);
+    font-size: var(--font-size-md);
+    font-weight: 600;
+    line-height: var(--line-height-normal);
+}
+
+.briefingSign {
+    display: block;
+    margin-top: var(--space-2);
+    color: var(--color-brand-strong);
+    font-size: var(--font-size-xs);
+    font-weight: 800;
+}
+
+.clothingRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.clothingChip {
+    padding: var(--space-1) var(--space-3);
+    border-radius: 999px;
+    background: var(--color-surface-muted);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 750;
+}
+
+/* ── 오늘 일정 ────────────────────────────────────────── */
+.emptyText {
+    margin: 0;
+    color: var(--color-text-subtle);
+    font-size: var(--font-size-sm);
+    font-weight: 650;
+}
+
+.scheduleList {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.scheduleItem {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-muted);
+}
+
+.scheduleDot {
+    width: var(--space-2);
+    height: var(--space-2);
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: var(--event-color, var(--color-brand));
+}
+
+.scheduleBody {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.scheduleTitle {
+    color: var(--color-text);
+    font-size: var(--font-size-base);
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.scheduleTime {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 650;
+}
+
+/* ── 진행률 ───────────────────────────────────────────── */
+.progressHeader {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-2);
+}
+
+.progressRate {
+    color: var(--color-brand-strong);
+    font-size: var(--font-size-lg);
+    font-weight: 800;
+}
+
+.progressBar {
+    height: var(--space-2);
+    border-radius: 999px;
+    background: var(--color-surface-muted);
+    overflow: hidden;
+}
+
+.progressFill {
+    height: 100%;
+    border-radius: 999px;
+    background: var(--color-brand);
+    transition: width 240ms ease;
+}
+
+.progressList {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.progressItem {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    border: 0;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--color-text);
+    text-align: left;
+    cursor: pointer;
+}
+
+.progressItem:hover {
+    background: var(--color-hover);
+}
+
+.checkbox {
+    display: grid;
+    place-items: center;
+    width: 18px;
+    height: 18px;
+    flex: 0 0 auto;
+    border: 1.5px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: transparent;
+    font-size: 11px;
+}
+
+.checkboxChecked {
+    border-color: var(--color-brand);
+    background: var(--color-brand);
+    color: #ffffff;
+}
+
+.progressItemTitle {
+    min-width: 0;
+    flex: 1;
+    font-size: var(--font-size-base);
+    font-weight: 650;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.progressItemDone {
+    color: var(--color-text-subtle);
+    text-decoration: line-through;
+}
+
+.sourceTag {
+    margin-left: auto;
+    flex: 0 0 auto;
+    padding: 1px var(--space-2);
+    border-radius: 999px;
+    background: var(--color-surface-muted);
+    color: var(--color-text-subtle);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+}
+
+/* ── 책장(시그니처) ───────────────────────────────────── */
+.bookshelf {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.bookshelfHeader {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+}
+
+.bookshelfTitle {
+    margin: 0;
+    color: var(--color-text);
+    font-size: var(--font-size-lg);
+    font-weight: 800;
+}
+
+.bookshelfHint {
+    color: var(--color-text-subtle);
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+}
+
+.shelfTop {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--space-6);
+    padding: 0 var(--space-6);
+    min-height: 132px;
+}
+
+.pot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-1);
+    border: 0;
+    background: transparent;
+    cursor: default;
+}
+
+.potArt {
+    position: relative;
+    width: 84px;
+    height: 104px;
+    display: grid;
+    place-items: end center;
+}
+
+.potLabel {
+    font-size: var(--font-size-xs);
+    font-weight: 800;
+    color: var(--color-text-muted);
+}
+
+.potGrowth {
+    font-size: 11px;
+    font-weight: 800;
+    color: var(--color-brand-strong);
+}
+
+.shelfPlank {
+    height: 18px;
+    border-radius: var(--radius-sm);
+    background: linear-gradient(
+            180deg,
+            var(--color-border) 0%,
+            var(--color-border-soft) 100%
+    );
+    box-shadow: var(--shadow-sm);
+}
+
+.shelfBooks {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: var(--space-2);
+    min-height: 96px;
+    padding: var(--space-4) var(--space-6) 0;
+    background: var(--color-cell-muted);
+    border-bottom-left-radius: var(--radius-md);
+    border-bottom-right-radius: var(--radius-md);
+}
+
+.book {
+    flex: 1 1 0;
+    max-width: 40px;
+    min-width: 22px;
+    border-top-left-radius: var(--radius-sm);
+    border-top-right-radius: var(--radius-sm);
+    background: var(--book-color, var(--color-brand));
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: var(--space-2);
+    cursor: pointer;
+    transition:
+            transform 160ms ease,
+            filter 160ms ease;
+}
+
+.book:hover {
+    transform: translateY(-6px);
+    filter: brightness(1.05);
+}
+
+.bookSpine {
+    color: var(--color-surface);
+    font-size: 9px;
+    font-weight: 800;
+    writing-mode: vertical-rl;
+    letter-spacing: 0.05em;
+}
+
+/* ── 반응형 ───────────────────────────────────────────── */
+@media (max-width: 1080px) {
+    .topGrid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 760px) {
+    .page {
+        padding: var(--space-6) var(--space-4);
+    }
+
+    .shelfTop {
+        gap: var(--space-3);
+        padding: 0 var(--space-3);
+        overflow-x: auto;
+    }
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,57 @@
+// src/lib/api/client.ts
+//
+// BE 연동을 위한 axios 인스턴스.
+//
+// 설계 원칙:
+//   - 인증: BE는 JWT Bearer 토큰 방식이다. 토큰은 로컬스토리지에서 가져온다.
+//     (추후 인증 스토어(zustand) 연동 시 이 파일만 수정한다.)
+//   - 에러: BE GlobalExceptionHandler의 ErrorResponse 형태(code, message)를
+//     ApiError로 래핑해 던진다. 호출부에서 code로 분기 처리할 수 있다.
+//   - baseURL: 환경변수 NEXT_PUBLIC_API_URL로 주입받는다.
+//     개발 환경에서는 .env.local에 설정하고, 운영에서는 BE 실제 주소로 바꾼다.
+
+import axios, { AxiosError } from 'axios'
+import type { ApiError, ApiErrorResponse } from '@/types/api'
+
+// BE baseURL. 설정되지 않은 경우 로컬 기본값으로 fallback.
+// Next.js는 next-env.d.ts를 통해 process.env.NEXT_PUBLIC_* 타입을 자동 제공한다.
+// 이 파일은 Next.js 프로젝트에서만 사용되므로 process.env 접근이 유효하다.
+const BASE_URL =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process as any).env?.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080'
+
+export const apiClient = axios.create({
+  baseURL: BASE_URL,
+  timeout: 10_000,
+  headers: { 'Content-Type': 'application/json' },
+})
+
+// 요청 인터셉터 — Authorization 헤더 주입
+// 현재 BE는 SecurityConfig에서 JWT 필터로 인증하므로, Access Token을 Bearer로 첨부한다.
+apiClient.interceptors.request.use((config) => {
+  // 브라우저 환경(클라이언트 컴포넌트)에서만 토큰을 읽는다.
+  // 서버 컴포넌트에서는 쿠키 기반 인증으로 전환 시 이 분기를 수정한다.
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('accessToken')
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+  }
+  return config
+})
+
+// 응답 인터셉터 — BE ErrorResponse → ApiError 변환
+// BE의 GlobalExceptionHandler는 항상 { timestamp, status, code, message, path }를 반환한다.
+// 호출부에서 code로 분기 처리할 수 있도록 ApiError 형태로 래핑한다.
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError<ApiErrorResponse>) => {
+    const data = error.response?.data
+    const apiError: ApiError = {
+      status: error.response?.status ?? 0,
+      code: data?.code ?? 'UNKNOWN',
+      message: data?.message ?? '알 수 없는 오류가 발생했습니다.',
+    }
+    return Promise.reject(apiError)
+  }
+)

--- a/src/lib/api/progress.ts
+++ b/src/lib/api/progress.ts
@@ -1,0 +1,39 @@
+// src/lib/api/progress.ts
+//
+// 오늘 기준 루틴+투두 진행률 패칭 함수.
+//
+// 현재 BE에서 진행률 패널에 필요한 두 데이터:
+//   1. 투두: GET /api/todo/by-day/{day}
+//      응답: TodoResponse[] (todoId, title, priority, status, categoryId)
+//   2. 루틴: GET /api/repeats
+//      응답: RepeatResponse[] (routineId, nodeId, startDate, endDate, active ...)
+//      → 루틴은 현재 RepeatResponse에 title이 없어 Node 조회가 필요하다.
+//        추후 BE에서 title을 포함한 응답 DTO를 제공하거나 별도 Node 조회 추가.
+//
+// 이 함수는 두 응답을 하나의 ProgressItem[] 으로 합쳐 반환한다.
+// 현재는 mock 반환. 실제 연동 시 아래 주석처럼 교체한다.
+//
+// 교체 예시:
+//   const [todos, repeats] = await Promise.all([
+//     apiClient.get<TodoResponse[]>(`/api/todo/by-day/${date}`),
+//     apiClient.get<RepeatResponse[]>('/api/repeats'),
+//   ])
+//   return [
+//     ...todos.data.map((t) => ({ id: String(t.todoId), title: t.title, done: t.status === 'ARCHIVED', source: 'TODO' as const })),
+//     ...repeats.data.map((r) => ({ id: String(r.routineId), title: `루틴 #${r.routineId}`, done: false, source: 'ROUTINE' as const })),
+//   ]
+
+import type { ProgressItem } from '@/types/main'
+
+const MOCK_PROGRESS: ProgressItem[] = [
+  { id: 'r-1', title: '물 2L 마시기', done: true, source: 'ROUTINE' },
+  { id: 'r-2', title: '아침 스트레칭', done: true, source: 'ROUTINE' },
+  { id: 't-1', title: '기획안 초안 작성', done: false, source: 'TODO' },
+  { id: 't-2', title: '읽던 책 30쪽', done: false, source: 'TODO' },
+]
+
+export async function getTodayProgress(_date: string): Promise<ProgressItem[]> {
+  // TODO: BE /api/todo/by-day/{date} + /api/repeats 연동 시 교체
+  // 루틴 title 포함 여부는 BE와 협의 후 결정
+  return MOCK_PROGRESS
+}

--- a/src/lib/api/schedule.ts
+++ b/src/lib/api/schedule.ts
@@ -1,0 +1,58 @@
+// src/lib/api/schedule.ts
+//
+// 일정(Schedule) 관련 API 패칭 함수.
+//
+// BE 엔드포인트: GET /api/schedules/day?date={yyyy-MM-dd}
+// BE 응답 DTO: ScheduleResponse (nodeId, date, startTime, endTime, allDay)
+//
+// 현재 상태:
+//   BE ScheduleResponse에는 일정 제목(title)이 없다.
+//   제목은 Node.title에 있으므로, 추후 BE에서 title을 포함한 응답 DTO를 제공하거나
+//   별도 Node 조회를 추가해야 한다.
+//   이 함수를 실제 fetch로 교체할 때 title 처리 방식을 함께 결정한다.
+//
+// 현재는 mock 데이터를 반환하며, 실제 연동 시 아래 주석처럼 교체한다.
+//
+// 교체 예시:
+//   const { data } = await apiClient.get<ScheduleResponse[]>('/api/schedules/day', {
+//     params: { date },
+//   })
+//   return data
+
+import type { TodayScheduleItem } from '@/types/main'
+
+// mock 데이터. BE에서 title을 포함한 응답을 주기 전까지 사용.
+const MOCK_SCHEDULE: TodayScheduleItem[] = [
+  {
+    nodeId: 1,
+    title: '아침 독서 모임',
+    startTime: '10:00:00',
+    endTime: '11:30:00',
+    allDay: false,
+    color: 'var(--color-study)',
+  },
+  {
+    nodeId: 2,
+    title: '오후 산책',
+    startTime: '15:00:00',
+    endTime: '16:00:00',
+    allDay: false,
+    color: 'var(--color-routine)',
+  },
+]
+
+export async function getTodaySchedule(
+  _date: string
+): Promise<TodayScheduleItem[]> {
+  // TODO: BE /api/schedules/day?date={date} 연동 시 교체
+  // title 포함 여부는 BE와 협의 후 결정
+  return MOCK_SCHEDULE
+}
+
+// 'HH:mm:ss' → 'HH:mm' 변환 유틸 (표시용)
+// BE의 LocalTime은 'HH:mm:ss' 형태로 직렬화된다.
+export function formatTime(time: string | null): string {
+  if (!time) return ''
+  // 'HH:mm:ss' → 'HH:mm'
+  return time.slice(0, 5)
+}

--- a/src/lib/api/weather.ts
+++ b/src/lib/api/weather.ts
@@ -1,0 +1,75 @@
+// src/lib/api/weather.ts
+//
+// 날씨 브리핑 데이터 패칭 경계.
+//
+// 현재 상태:
+//   BE에 메인 페이지용 날씨 엔드포인트가 아직 없다.
+//   실제 흐름은 FE → BE(Spring Boot) → AI 서버(POST /api/v1/weather/briefing)이므로,
+//   BE 엔드포인트가 확정되면 이 함수 본문만 아래 주석처럼 교체한다.
+//
+// 교체 예시 (BE 엔드포인트 확정 후):
+//   const { data } = await apiClient.get<{ message: string; icon_code: WeatherIconCode; clothing: ClothingCode[] }>(
+//     '/api/main/weather',
+//   )
+//   return { message: data.message, iconCode: data.icon_code, clothing: data.clothing }
+//
+// snake_case → camelCase 변환은 이 함수가 책임진다.
+// 컴포넌트는 반환 타입(WeatherBriefing)에만 의존하므로, 교체 시 UI 변경 없음.
+
+import type {
+  ClothingCode,
+  WeatherBriefing,
+  WeatherIconCode,
+} from '@/types/weather'
+
+// 아이콘 코드 → 한국어 라벨 (aria-label 및 보조 텍스트용)
+const ICON_LABEL: Record<WeatherIconCode, string> = {
+  SUNNY: '맑음',
+  PARTLY_CLOUDY: '구름 조금',
+  CLOUDY: '흐림',
+  RAINY: '비',
+  HEAVY_RAIN: '폭우',
+  SNOWY: '눈',
+  HEAVY_SNOW: '폭설',
+  THUNDERSTORM: '천둥번개',
+  FOGGY: '안개',
+  YELLOW_DUST: '황사',
+  TYPHOON: '태풍',
+}
+
+export function getWeatherLabel(code: WeatherIconCode): string {
+  return ICON_LABEL[code]
+}
+
+// 의류 코드 → 한국어 라벨 (추천 의류 칩 표시용)
+const CLOTHING_LABEL: Record<ClothingCode, string> = {
+  T_SHIRT: '반팔',
+  LONG_SLEEVE: '긴소매',
+  LIGHT_JACKET: '얇은 외투',
+  JACKET: '재킷',
+  COAT: '코트',
+  PADDED_JACKET: '패딩',
+  JEANS: '청바지',
+  SHORTS: '반바지',
+  UMBRELLA: '우산',
+  SUNSCREEN: '자외선 차단제',
+  MASK: '마스크',
+}
+
+export function getClothingLabel(code: ClothingCode): string {
+  return CLOTHING_LABEL[code]
+}
+
+// ── 패칭 경계 함수 ────────────────────────────────────────────────────────────
+// async로 선언해두어, 실제 fetch 교체 시 호출부 변경이 없도록 한다.
+const MOCK_BRIEFING: WeatherBriefing = {
+  message:
+    '오늘은 햇살이 제법 포근하게 드는 하루예요. 가볍게 긴소매 하나만 걸치셔도 충분할 것 같으니, 산책 한 번 다녀오시는 건 어떨까요.',
+  iconCode: 'SUNNY',
+  clothing: ['LONG_SLEEVE', 'LIGHT_JACKET'],
+}
+
+export async function getTodayBriefing(): Promise<WeatherBriefing> {
+  // TODO: BE /api/main/weather 엔드포인트 확정 후 실제 fetch로 교체
+  return MOCK_BRIEFING
+}

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -1,0 +1,55 @@
+// src/lib/main.ts
+//
+// 메인 페이지 공통 유틸리티 및 책장 관련 mock 데이터.
+
+import type { ArchivedBook, BookshelfPot } from '@/types/main'
+
+// 오늘 날짜. 서버 컴포넌트에서 사용하므로 서버 기준 시각을 사용한다.
+// 'YYYY-MM-DD' 형태로 반환.
+export function getTodayIso(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+// 'YYYY-MM-DD' → '2026. 03. 08. 일요일' 형태 변환 (메인 페이지 날짜 헤더용)
+const WEEKDAY_KO = ['일', '월', '화', '수', '목', '금', '토']
+
+export function formatKoreanDate(iso: string): string {
+  const date = new Date(`${iso}T00:00:00`)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const weekday = WEEKDAY_KO[date.getDay()]
+  return `${year}. ${month}. ${day}. ${weekday}요일`
+}
+
+// ── 책장 화분 mock ────────────────────────────────────────────────────────────
+// 추후 BE의 일별 활동 요약(DailySummary) API와 연동될 자리.
+// growth = 완료율(0.0~1.0). 'all'은 나머지 셋의 평균.
+const routineGrowth = 0.8
+const diaryGrowth = 0.5
+const todoGrowth = 0.35
+
+export const bookshelfPots: BookshelfPot[] = [
+  {
+    id: 'all',
+    label: '전체',
+    growth:
+      Math.round(((routineGrowth + diaryGrowth + todoGrowth) / 3) * 100) / 100,
+  },
+  { id: 'routine', label: '루틴', growth: routineGrowth },
+  { id: 'diary', label: '일기', growth: diaryGrowth },
+  { id: 'todo', label: '투두', growth: todoGrowth },
+]
+
+// ── 아카이빙 책 mock ──────────────────────────────────────────────────────────
+// completion이 낮을수록 "빛바랜 종이"처럼 옅게 표현한다.
+// ERD의 '일별 활동 요약(DailySummary)'과 이어질 자리.
+export const archivedBooks: ArchivedBook[] = [
+  { date: '2026-03-01', completion: 0.9, spineLabel: '3/1' },
+  { date: '2026-03-02', completion: 0.4, spineLabel: '3/2' },
+  { date: '2026-03-03', completion: 0.7, spineLabel: '3/3' },
+  { date: '2026-03-04', completion: 1.0, spineLabel: '3/4' },
+  { date: '2026-03-05', completion: 0.55, spineLabel: '3/5' },
+  { date: '2026-03-06', completion: 0.25, spineLabel: '3/6' },
+  { date: '2026-03-07', completion: 0.85, spineLabel: '3/7' },
+]

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,19 @@
+// src/types/api.ts
+//
+// BE GlobalExceptionHandler의 ErrorResponse와 1:1 대응하는 FE 타입.
+// 모든 API 에러 응답은 이 형태로 내려온다.
+
+export type ApiErrorResponse = {
+  timestamp: string // ISO 8601
+  status: number
+  code: string // ex) "COMMON_500", "AUTH_401"
+  message: string
+  path: string
+}
+
+// axios 인터셉터에서 에러를 이 타입으로 래핑해 던지도록 한다.
+export type ApiError = {
+  status: number
+  code: string
+  message: string
+}

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -1,0 +1,70 @@
+// src/types/main.ts
+//
+// 메인 페이지(대시보드)에서 사용하는 도메인 타입.
+// BE의 실제 응답 DTO와 1:1로 대응한다.
+
+// ── 일정 ─────────────────────────────────────────────────────────────────────
+// BE: ScheduleResponse (ScheduleController → GET /api/schedules/day?date=)
+// BE 필드: nodeId(Long), date(LocalDate), startTime(LocalTime),
+//          endTime(LocalTime), allDay(boolean)
+export type ScheduleResponse = {
+  nodeId: number
+  date: string // 'YYYY-MM-DD'
+  startTime: string | null // 'HH:mm:ss' (allDay이면 null일 수 있음)
+  endTime: string | null
+  allDay: boolean
+}
+
+// FE 표시용 — ScheduleResponse에 title/color를 추가한 뷰 모델.
+// 현재 BE ScheduleResponse에는 title이 없으므로(Node.title로 별도 조회 필요),
+// mock 단계에서는 title을 직접 포함시키고, BE 연동 시 Node 조회를 추가한다.
+export type TodayScheduleItem = {
+  nodeId: number
+  title: string
+  startTime: string | null
+  endTime: string | null
+  allDay: boolean
+  color: string // 카테고리 색 토큰 (ex. 'var(--color-study)')
+}
+
+// ── 투두 ─────────────────────────────────────────────────────────────────────
+// BE: TodoResponse (TodoController → GET /api/todo/by-day/{day})
+// BE 필드: todoId(Long), title(String), priority(Priority),
+//          status(TodoStatus), categoryId(Integer | null)
+export type TodoResponse = {
+  todoId: number
+  title: string
+  priority: 'LOW' | 'MEDIUM' | 'HIGH'
+  status: 'ACTIVE' | 'ARCHIVED'
+  categoryId: number | null
+}
+
+// ── 진행률 패널 (루틴 + 투두 통합) ───────────────────────────────────────────
+// 루틴(Repeat)과 투두(Todo)를 source 필드로 구분해 하나의 리스트로 표시한다.
+// BE의 TodoExecution.SourceType(MANUAL | SCHEDULE | REPEAT)에서 착안.
+export type ProgressItem = {
+  id: string
+  title: string
+  done: boolean
+  source: 'ROUTINE' | 'TODO'
+}
+
+// ── 책장 화분 ─────────────────────────────────────────────────────────────────
+// 활동량(완료율)에 따라 새싹이 자라는 게이지.
+// 추후 BE의 일별 활동 요약(DailySummary) API와 연동될 자리.
+export type BookshelfPotId = 'all' | 'routine' | 'diary' | 'todo'
+
+export type BookshelfPot = {
+  id: BookshelfPotId
+  label: string
+  growth: number // 0.0 ~ 1.0
+}
+
+// ── 아카이빙 책 ───────────────────────────────────────────────────────────────
+// 과거 날짜별 기록. completion이 낮을수록 책등이 옅어진다("빛바랜 종이").
+// ERD의 '일별 활동 요약(DailySummary)'과 이어질 자리.
+export type ArchivedBook = {
+  date: string // 'YYYY-MM-DD'
+  completion: number // 0.0 ~ 1.0
+  spineLabel: string // 책등 표시 라벨 (ex. '3/1')
+}

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -1,0 +1,43 @@
+// src/types/weather.ts
+//
+// Dayleaf-AI 서버(POST /api/v1/weather/briefing)의 응답 스키마와 1:1 대응.
+// BE가 AI 서버를 호출한 뒤 FE로 전달하는 최종 응답 형태.
+//
+// 설계 원칙:
+//   - AI 계약의 snake_case(icon_code, clothing)를 FE camelCase로 변환해 정의한다.
+//   - lib/api/weather.ts의 패칭 함수에서 변환 책임을 진다.
+
+// 날씨 아이콘 코드 (AI 계약 IconCode와 1:1)
+export type WeatherIconCode =
+  | 'SUNNY'
+  | 'PARTLY_CLOUDY'
+  | 'CLOUDY'
+  | 'RAINY'
+  | 'HEAVY_RAIN'
+  | 'SNOWY'
+  | 'HEAVY_SNOW'
+  | 'THUNDERSTORM'
+  | 'FOGGY'
+  | 'YELLOW_DUST'
+  | 'TYPHOON'
+
+// 추천 의류 코드 (AI 계약 Clothing과 1:1)
+export type ClothingCode =
+  | 'T_SHIRT'
+  | 'LONG_SLEEVE'
+  | 'LIGHT_JACKET'
+  | 'JACKET'
+  | 'COAT'
+  | 'PADDED_JACKET'
+  | 'JEANS'
+  | 'SHORTS'
+  | 'UMBRELLA'
+  | 'SUNSCREEN'
+  | 'MASK'
+
+// FE에서 사용하는 날씨 브리핑 (camelCase 변환 완료 상태)
+export type WeatherBriefing = {
+  message: string
+  iconCode: WeatherIconCode
+  clothing: ClothingCode[]
+}


### PR DESCRIPTION
## 📣 Related Issue

- #14 

## 📝 Summary

- 날씨 AI 브리핑 카드 구현 (`WeatherBriefing`) — Dayleaf-AI API 계약과 동기화된 타입으로 사서 리프의 메시지, 날씨 아이콘, 추천 의류 칩을 표시
- 오늘 일정 카드 구현 (`TodaySchedule`) — 카테고리 색 토큰 연동, 종일 일정 처리 포함
- 루틴+투두 진행률 패널 구현 (`TodayProgress`) — 체크박스 토글 상태관리, 실시간 퍼센트 및 프로그레스 바 반영
- 기록 책장 구현 (`Bookshelf` + `PlantPot`) — growth 비율에 따라 새싹이 자라는 화분 SVG, 완료율에 따라 색이 옅어지는 아카이빙 책 표현
- 메인 페이지 조립 (`src/app/page.tsx`) — 와이어프레임 구조(날짜 헤더 → 3분할 카드 → 책장) 반영, 서버/클라이언트 컴포넌트 분리

## 🙏 PR point

- **날씨 데이터는 현재 mock**: `src/lib/weather.ts`의 `getTodayBriefing()` 함수 한 곳만 수정하면 실 fetch로 전환 가능하도록 경계를 격리해뒀습니다. FE → BE → AI 서버 흐름이 확정되면 이 함수만 교체하면 됩니다.
- **서버/클라이언트 분리**: 체크박스 토글 상태가 필요한 `TodayProgress`만 `'use client'`로 분리했습니다. 나머지는 전부 서버 컴포넌트입니다.
- **기존 디자인 토큰 100% 준수**: `globals.css`의 `--color-*`, `--space-*`, `--radius-*` 토큰만 사용했고 새로운 색상 값은 추가하지 않았습니다.
- **WeatherIcon 외부 라이브러리 미사용**: 기존 코드베이스가 아이콘 라이브러리를 쓰지 않아 11종 날씨 코드를 모두 인라인 SVG로 구현했습니다.

## 📬 Reference

- Dayleaf-AI API 계약: `Dayleaf-AI/docs/api-contract.md`
- 와이어프레임: 메인 페이지 디자인 시안 (2026.03 기준)